### PR TITLE
fix: use new api_client in oauth api handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Plane REST API
 Visit our quick start guide and full API documentation at [developers.plane.so](https://developers.plane.so/api-reference/introduction).
 
 - API version: 0.0.1
-- Package version: 0.1.8
+- Package version: 0.1.9
 - Generator version: 7.13.0
 - Build package: org.openapitools.codegen.languages.PythonClientCodegen
 For more information, please visit [https://plane.so](https://plane.so)

--- a/plane/__init__.py
+++ b/plane/__init__.py
@@ -15,7 +15,7 @@
 """  # noqa: E501
 
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 # import apis into sdk package
 from plane.api.assets_api import AssetsApi

--- a/plane/api_client.py
+++ b/plane/api_client.py
@@ -86,7 +86,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/0.1.8/python'
+        self.user_agent = 'OpenAPI-Generator/0.1.9/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/plane/configuration.py
+++ b/plane/configuration.py
@@ -548,7 +548,7 @@ conf = plane.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 0.0.1\n"\
-               "SDK Package Version: 0.1.8".\
+               "SDK Package Version: 0.1.9".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:

--- a/plane/oauth/api.py
+++ b/plane/oauth/api.py
@@ -81,9 +81,9 @@ class OAuthApi:
         try:
             response = self.api_client.call_api(
                 "POST",
-                "/auth/o/token/",
+                f"{self.base_url}/auth/o/token/",
                 header_params=headers,
-                body=data,
+                post_params=data,
             )
             response.read()
             json_response = json.loads(response.data)
@@ -112,15 +112,11 @@ class OAuthApi:
         }
 
         try:
-            response = self.rest_client.post_request(
-                url=f"{self.base_url}/auth/o/token/", headers=headers, post_params=data
-            )
-
             response = self.api_client.call_api(
                 "POST",
-                "/auth/o/token/",
+                f"{self.base_url}/auth/o/token/",
                 header_params=headers,
-                body=data,
+                post_params=data,
             )
             response.read()
             json_response = json.loads(response.data)
@@ -148,15 +144,11 @@ class OAuthApi:
         }
 
         try:
-            response = self.rest_client.post_request(
-                url=f"{self.base_url}/auth/o/token/", headers=headers, post_params=data
-            )
-
             response = self.api_client.call_api(
                 "POST",
-                "/auth/o/token/",
+                f"{self.base_url}/auth/o/token/",
                 header_params=headers,
-                body=data,
+                post_params=data,
             )
             response.read()
             json_response = json.loads(response.data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plane"
-version = "0.1.8"
+version = "0.1.9"
 description = "The Plane REST API"
 authors = ["Plane <support@plane.so>"]
 license = "GNU AGPLv3"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 NAME = "plane-sdk"
-VERSION = "0.1.8"
+VERSION = "0.1.9"
 PYTHON_REQUIRES = ">= 3.9"
 REQUIRES = [
     "urllib3 >= 2.1.0, < 3.0.0",


### PR DESCRIPTION
### Description
- In oauth/api.py, use the new api_client for making oauth calls for pydantic v2

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth token requests to use absolute URLs and form parameters, ensuring consistent token retrieval without changing the public API.

* **Documentation**
  * README updated to reflect version 0.1.9.

* **Chores**
  * Bumped package version to 0.1.9 across the project.
  * Updated default User-Agent and debug report to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->