### PR TITLE
fix: correct State.sequence type to float and WorkItem.state to accept expanded objects

### DIFF
--- a/plane/models/states.py
+++ b/plane/models/states.py
@@ -16,7 +16,7 @@ class State(BaseModel):
     name: str
     description: str | None = None
     color: str
-    sequence: int | None = None
+    sequence: float | None = None
     group: GroupEnum | None = None
     is_triage: bool | None = None
     default: bool | None = None
@@ -47,7 +47,7 @@ class CreateState(BaseModel):
     name: str
     description: str | None = None
     color: str
-    sequence: int | None = None
+    sequence: float | None = None
     group: GroupEnum | None = None
     is_triage: bool | None = None
     default: bool | None = None
@@ -63,7 +63,7 @@ class UpdateState(BaseModel):
     name: str | None = None
     description: str | None = None
     color: str | None = None
-    sequence: int | None = None
+    sequence: float | None = None
     group: GroupEnum | None = None
     is_triage: bool | None = None
     default: bool | None = None

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -42,7 +42,7 @@ class WorkItem(BaseModel):
     project: str | None = None
     workspace: str | None = None
     parent: str | None = None
-    state: str | None = None
+    state: str | StateLite | None = None
     estimate_point: str | None = None
     type: str | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plane-sdk"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python SDK for Plane API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Fixes two Pydantic model type mismatches that cause validation errors in downstream consumers (e.g. `plane-mcp-server`).

Related: https://github.com/makeplane/plane-mcp-server/issues/83

## Changes

### 1. `State.sequence`: `int` → `float`

The Plane API's `State` model uses a Django `FloatField` for `sequence` ([source](https://github.com/makeplane/plane-ee/blob/canary/apps/api/plane/db/models/state.py#L92)), so the API returns values like `-57052.5` and `8482.5`. The SDK model declared this as `int | None`, causing Pydantic validation errors.

Updated in `State`, `CreateState`, and `UpdateState`.

### 2. `WorkItem.state`: `str` → `str | StateLite`

When the `expand` query parameter includes `state`, the API returns an expanded state object (with `id`, `name`, `color`, `group`) instead of a UUID string. `WorkItemDetail` already handles this correctly (`str | StateLite | None`), but `WorkItem` (used by `PaginatedWorkItemResponse`) only accepted `str | None`.