### PR TITLE
feat: add project_id and workspace_search to AdvancedSearchWorkItem

### DIFF
--- a/plane/models/query_params.py
+++ b/plane/models/query_params.py
@@ -1,6 +1,6 @@
 """Query parameter DTOs for list/retrieve endpoints."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
 
 class BaseQueryParams(BaseModel):
@@ -61,6 +61,48 @@ class WorkItemQueryParams(PaginatedQueryParams):
     """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    assignee_id__in: list[str] | None = Field(
+        None,
+        description="Filter by assignee UUIDs",
+    )
+    state_id__in: list[str] | None = Field(
+        None,
+        description="Filter by state UUIDs",
+    )
+    state_group__in: list[str] | None = Field(
+        None,
+        description="Filter by state groups (backlog, unstarted, started, completed, cancelled)",
+    )
+    priority__in: list[str] | None = Field(
+        None,
+        description="Filter by priority levels (urgent, high, medium, low, none)",
+    )
+    label_id__in: list[str] | None = Field(
+        None,
+        description="Filter by label UUIDs",
+    )
+    created_by_id__in: list[str] | None = Field(
+        None,
+        description="Filter by creator user UUIDs",
+    )
+    is_draft: bool | None = Field(
+        None,
+        description="Filter by draft status",
+    )
+    is_archived: bool | None = Field(
+        None,
+        description="Filter by archived status",
+    )
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):  # type: ignore[no-untyped-def]
+        """Serialize list fields as comma-separated strings for django-filters."""
+        data = handler(self)
+        for key, value in data.items():
+            if isinstance(value, list):
+                data[key] = ",".join(str(v) for v in value)
+        return data
 
 
 class RetrieveQueryParams(BaseQueryParams):

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -245,6 +245,8 @@ class AdvancedSearchWorkItem(BaseModel):
     query: str | None = None
     filters: dict[str, Any] | None = None
     limit: int | None = None
+    project_id: str | None = None
+    workspace_search: bool | None = None
 
 
 class AdvancedSearchResult(BaseModel):


### PR DESCRIPTION
## Summary

Adds `project_id` and `workspace_search` fields to `AdvancedSearchWorkItem` model, and adds filter fields to `WorkItemQueryParams`.

## Changes

### `AdvancedSearchWorkItem`
- Added `project_id` — scope search to a specific project
- Added `workspace_search` — search across all projects in the workspace

These fields are already supported by the API (`WorkItemAdvancedSearchRequestSerializer`) but were missing from the SDK model.

### `WorkItemQueryParams`
- Added filter fields (`assignee_id__in`, `state_group__in`, `priority__in`, etc.) for future use when the public API list endpoint adds `IssueFilterSet` support.

## Verified
- All 13 unit tests pass against UAT
- Advanced search with `project_id` and `workspace_search` tested end-to-end

## Companion PR
- [plane-mcp-server#88](https://github.com/makeplane/plane-mcp-server/pull/88) — adds `advanced_search_work_items` MCP tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced work item filtering with options to filter by assignees, states, state groups, priorities, labels, and creators.
  * Added draft and archived status filtering for work items.
  * Advanced search accepts project-scoped and workspace-level search flags.
  * List-based filters are now accepted as comma-separated parameters for queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->