### PR TITLE
fix: make WorkItemDetail assignees/labels optional for sparse responses

### DIFF
--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -53,8 +53,8 @@ class WorkItemDetail(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     id: str | None = None
-    assignees: list[UserLite]
-    labels: list[Label]
+    assignees: list[UserLite] = []
+    labels: list[Label] = []
     type_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None

--- a/tests/unit/test_work_item_detail_sparse.py
+++ b/tests/unit/test_work_item_detail_sparse.py
@@ -1,0 +1,94 @@
+"""Tests for WorkItemDetail parsing with sparse API responses (MFT-34).
+
+When the Plane API is called with a ``fields`` parameter, it returns only the
+requested fields.  ``assignees`` and ``labels`` may be absent.  These tests
+verify that ``WorkItemDetail`` handles both full and sparse payloads without
+raising a ``ValidationError``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from plane.models.work_items import WorkItemDetail
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+FULL_RESPONSE = {
+    "id": "abc-123",
+    "name": "Test item",
+    "assignees": [
+        {
+            "id": "user-1",
+            "first_name": "Alice",
+            "last_name": "Smith",
+            "email": "alice@example.com",
+            "display_name": "alice",
+        }
+    ],
+    "labels": [
+        {
+            "id": "label-1",
+            "name": "Bug",
+            "color": "#FF0000",
+        }
+    ],
+    "priority": "high",
+    "state": "state-uuid",
+    "project": "proj-uuid",
+    "workspace": "ws-uuid",
+}
+
+SPARSE_RESPONSE_NO_ASSIGNEES_LABELS = {
+    "id": "abc-123",
+    "name": "Test item",
+    "state": "state-uuid",
+}
+
+SPARSE_RESPONSE_ID_AND_NAME_ONLY = {
+    "id": "abc-123",
+    "name": "Test item",
+}
+
+
+# -- Tests -------------------------------------------------------------------
+
+
+class TestWorkItemDetailSparseResponse:
+    """Regression tests for MFT-34: fields parameter causes ValidationError."""
+
+    def test_full_response_parses(self):
+        """Full API response (with assignees + labels) still works."""
+        item = WorkItemDetail.model_validate(FULL_RESPONSE)
+        assert item.id == "abc-123"
+        assert len(item.assignees) == 1
+        assert item.assignees[0].id == "user-1"
+        assert len(item.labels) == 1
+        assert item.labels[0].name == "Bug"
+
+    def test_sparse_response_without_assignees_and_labels(self):
+        """Sparse response (fields=id,name,state) must not raise ValidationError."""
+        item = WorkItemDetail.model_validate(SPARSE_RESPONSE_NO_ASSIGNEES_LABELS)
+        assert item.id == "abc-123"
+        assert item.name == "Test item"
+        assert item.assignees == []
+        assert item.labels == []
+
+    def test_sparse_response_id_and_name_only(self):
+        """Minimal sparse response (fields=id,name) must not raise."""
+        item = WorkItemDetail.model_validate(SPARSE_RESPONSE_ID_AND_NAME_ONLY)
+        assert item.id == "abc-123"
+        assert item.assignees == []
+        assert item.labels == []
+
+    def test_empty_assignees_and_labels_accepted(self):
+        """Explicit empty lists are accepted (normal case with no assignees)."""
+        data = {**FULL_RESPONSE, "assignees": [], "labels": []}
+        item = WorkItemDetail.model_validate(data)
+        assert item.assignees == []
+        assert item.labels == []
+
+    def test_name_still_required(self):
+        """``name`` is still required — sparse responses always include it."""
+        with pytest.raises(ValidationError):
+            WorkItemDetail.model_validate({"id": "abc-123"})


### PR DESCRIPTION
## Summary

- **`WorkItemDetail.assignees`** and **`WorkItemDetail.labels`** are changed from required fields to optional with a default of `[]`
- When the Plane API is called with a `fields` parameter (e.g., `fields=id,name,state`), it returns a sparse response that omits `assignees` and `labels`, causing a pydantic `ValidationError`
- This is consistent with `WorkItemExpand`, which already treats these fields as optional

## Details

The fix is a one-line change per field in `plane/models/work_items.py`:

```python
# Before (required — fails on sparse responses)
assignees: list[UserLite]
labels: list[Label]

# After (optional with default — works for both full and sparse responses)
assignees: list[UserLite] = []
labels: list[Label] = []
```

## Test plan

- [x] New unit tests added in `tests/unit/test_work_item_detail_sparse.py`:
  - Full response with assignees + labels still parses correctly
  - Sparse response without assignees/labels no longer raises `ValidationError`
  - Minimal `fields=id,name` response works
  - Explicit empty lists still accepted
  - `name` remains a required field (no over-relaxation)
- [x] All 5 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of work item details when API responses contain incomplete data—missing assignees and labels are now treated as empty values instead of causing errors.

* **Tests**
  * Added comprehensive test coverage for sparse API response scenarios to ensure robust data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->