### PR TITLE
chore: add optional title field to work item link models

### DIFF
--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -368,6 +368,7 @@ class CreateWorkItemLink(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     url: str
+    title: str | None = None
 
 
 class UpdateWorkItemLink(BaseModel):
@@ -376,6 +377,7 @@ class UpdateWorkItemLink(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     url: str | None = None
+    title: str | None = None
 
 
 class WorkItemAttachment(BaseModel):

--- a/tests/unit/test_work_items.py
+++ b/tests/unit/test_work_items.py
@@ -5,7 +5,7 @@ import pytest
 from plane.client import PlaneClient
 from plane.models.projects import Project
 from plane.models.query_params import PaginatedQueryParams, WorkItemQueryParams
-from plane.models.work_items import AdvancedSearchWorkItem, CreateWorkItem, UpdateWorkItem
+from plane.models.work_items import AdvancedSearchWorkItem, CreateWorkItem, CreateWorkItemLink, UpdateWorkItem, UpdateWorkItemLink
 
 
 class TestWorkItemsAPI:
@@ -235,6 +235,49 @@ class TestWorkItemsSubResources:
         assert hasattr(response, "results")
         assert hasattr(response, "count")
         assert isinstance(response.results, list)
+
+    def test_create_link_with_title(
+        self, client: PlaneClient, workspace_slug: str, project: Project, work_item
+    ) -> None:
+        """Test creating a work item link with title."""
+        link = None
+        try:
+            link = client.work_items.links.create(
+                workspace_slug,
+                project.id,
+                work_item.id,
+                CreateWorkItemLink(url="https://example.com", title="Example"),
+            )
+            assert link is not None
+            assert link.url == "https://example.com"
+            assert link.title == "Example"
+        finally:
+            if link is not None:
+                client.work_items.links.delete(workspace_slug, project.id, work_item.id, link.id)
+
+    def test_update_link_title(
+        self, client: PlaneClient, workspace_slug: str, project: Project, work_item
+    ) -> None:
+        """Test updating a work item link title."""
+        link = None
+        try:
+            link = client.work_items.links.create(
+                workspace_slug,
+                project.id,
+                work_item.id,
+                CreateWorkItemLink(url="https://example.com", title="Original"),
+            )
+            updated = client.work_items.links.update(
+                workspace_slug,
+                project.id,
+                work_item.id,
+                link.id,
+                UpdateWorkItemLink(title="Updated"),
+            )
+            assert updated.title == "Updated"
+        finally:
+            if link is not None:
+                client.work_items.links.delete(workspace_slug, project.id, work_item.id, link.id)
 
     def test_list_activities(
         self, client: PlaneClient, workspace_slug: str, project: Project, work_item


### PR DESCRIPTION
### Description
- Add title: str | None = None to CreateWorkItemLink and UpdateWorkItemLink request models
- Previously only url was accepted — any title passed by callers was silently dropped by Pydantic's extra="ignore" config.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work item links can now include optional titles when creating or updating them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->