### PR TITLE
[INFRA-394] feat: add workspace-level API resources to SDK

### DIFF
--- a/plane/__init__.py
+++ b/plane/__init__.py
@@ -7,13 +7,20 @@ from .api.milestones import Milestones
 from .api.modules import Modules
 from .api.pages import Pages
 from .api.projects import Projects
+from .api.releases import Releases
 from .api.states import States
 from .api.stickies import Stickies
 from .api.teamspaces import Teamspaces
 from .api.users import Users
 from .api.work_item_properties import WorkItemProperties
+from .api.work_item_relation_definitions import WorkItemRelationDefinitions
 from .api.work_item_types import WorkItemTypes
 from .api.work_items import WorkItems
+from .api.workspace_project_labels import WorkspaceProjectLabels
+from .api.workspace_project_states import WorkspaceProjectStates
+from .api.workspace_templates import WorkspaceTemplates
+from .api.workspace_work_item_properties import WorkspaceWorkItemProperties
+from .api.workspace_work_item_types import WorkspaceWorkItemTypes
 from .api.workspaces import Workspaces
 from .client import (
     OAuthAuthorizationParams,
@@ -35,6 +42,7 @@ __all__ = [
     "WorkItems",
     "WorkItemTypes",
     "WorkItemProperties",
+    "WorkItemRelationDefinitions",
     "Projects",
     "Labels",
     "States",
@@ -48,6 +56,12 @@ __all__ = [
     "Estimates",
     "Pages",
     "Workspaces",
+    "Releases",
+    "WorkspaceTemplates",
+    "WorkspaceWorkItemTypes",
+    "WorkspaceWorkItemProperties",
+    "WorkspaceProjectLabels",
+    "WorkspaceProjectStates",
     "PlaneError",
     "ConfigurationError",
     "HttpError",

--- a/plane/api/releases/__init__.py
+++ b/plane/api/releases/__init__.py
@@ -1,0 +1,3 @@
+from .base import Releases
+
+__all__ = ["Releases"]

--- a/plane/api/releases/base.py
+++ b/plane/api/releases/base.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+from ...models.releases import CreateRelease, Release, UpdateRelease
+from ..base_resource import BaseResource
+from .item_labels import ReleaseItemLabels
+from .labels import ReleaseLabels
+from .tags import ReleaseTags
+
+
+class Releases(BaseResource):
+    """API client for managing workspace-level releases."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+        # Initialize sub-resources
+        self.tags = ReleaseTags(config)
+        self.labels = ReleaseLabels(config)
+        self.item_labels = ReleaseItemLabels(config)
+
+    def list(self, workspace_slug: str) -> list[Release]:
+        """List all releases in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/releases/")
+        return [Release.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateRelease) -> Release:
+        """Create a new release in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Release data
+        """
+        response = self._post(
+            f"{workspace_slug}/releases/",
+            data.model_dump(exclude_none=True),
+        )
+        return Release.model_validate(response)
+
+    def update(self, workspace_slug: str, release_id: str, data: UpdateRelease) -> Release:
+        """Update a release in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            release_id: UUID of the release
+            data: Updated release data
+        """
+        response = self._patch(
+            f"{workspace_slug}/releases/{release_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return Release.model_validate(response)

--- a/plane/api/releases/item_labels.py
+++ b/plane/api/releases/item_labels.py
@@ -22,7 +22,7 @@ class ReleaseItemLabels(BaseResource):
         response = self._get(f"{workspace_slug}/releases/{release_id}/labels/")
         return [ReleaseLabel.model_validate(item) for item in response]
 
-    def add(
+    def create(
         self, workspace_slug: str, release_id: str, data: AddReleaseItemLabel
     ) -> list[ReleaseLabel]:
         """Add labels to a release.
@@ -38,7 +38,7 @@ class ReleaseItemLabels(BaseResource):
         )
         return [ReleaseLabel.model_validate(item) for item in response]
 
-    def remove(self, workspace_slug: str, release_id: str, label_id: str) -> None:
+    def delete(self, workspace_slug: str, release_id: str, label_id: str) -> None:
         """Remove a label from a release.
 
         Args:

--- a/plane/api/releases/item_labels.py
+++ b/plane/api/releases/item_labels.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...models.releases import AddReleaseItemLabel, ReleaseLabel
+from ..base_resource import BaseResource
+
+
+class ReleaseItemLabels(BaseResource):
+    """API client for managing labels on a specific release."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str, release_id: str) -> list[ReleaseLabel]:
+        """List labels assigned to a release.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            release_id: UUID of the release
+        """
+        response = self._get(f"{workspace_slug}/releases/{release_id}/labels/")
+        return [ReleaseLabel.model_validate(item) for item in response]
+
+    def add(
+        self, workspace_slug: str, release_id: str, data: AddReleaseItemLabel
+    ) -> list[ReleaseLabel]:
+        """Add labels to a release.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            release_id: UUID of the release
+            data: Label IDs to add
+        """
+        response = self._post(
+            f"{workspace_slug}/releases/{release_id}/labels/",
+            data.model_dump(exclude_none=True),
+        )
+        return [ReleaseLabel.model_validate(item) for item in response]
+
+    def remove(self, workspace_slug: str, release_id: str, label_id: str) -> None:
+        """Remove a label from a release.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            release_id: UUID of the release
+            label_id: UUID of the label to remove
+        """
+        return self._delete(f"{workspace_slug}/releases/{release_id}/labels/{label_id}/")

--- a/plane/api/releases/labels.py
+++ b/plane/api/releases/labels.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from ...models.releases import CreateReleaseLabel, ReleaseLabel
+from ..base_resource import BaseResource
+
+
+class ReleaseLabels(BaseResource):
+    """API client for managing release labels."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[ReleaseLabel]:
+        """List all release labels in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/releases/labels/")
+        return [ReleaseLabel.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateReleaseLabel) -> ReleaseLabel:
+        """Create a new release label in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Release label data
+        """
+        response = self._post(
+            f"{workspace_slug}/releases/labels/",
+            data.model_dump(exclude_none=True),
+        )
+        return ReleaseLabel.model_validate(response)

--- a/plane/api/releases/tags.py
+++ b/plane/api/releases/tags.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from ...models.releases import CreateReleaseTag, ReleaseTag
+from ..base_resource import BaseResource
+
+
+class ReleaseTags(BaseResource):
+    """API client for managing release tags."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[ReleaseTag]:
+        """List all release tags in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/releases/tags/")
+        return [ReleaseTag.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateReleaseTag) -> ReleaseTag:
+        """Create a new release tag in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Release tag data
+        """
+        response = self._post(
+            f"{workspace_slug}/releases/tags/",
+            data.model_dump(exclude_none=True),
+        )
+        return ReleaseTag.model_validate(response)

--- a/plane/api/work_item_relation_definitions.py
+++ b/plane/api/work_item_relation_definitions.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from ..models.work_item_relation_definitions import (
+    CreateWorkItemRelationDefinition,
+    UpdateWorkItemRelationDefinition,
+    WorkItemRelationDefinition,
+)
+from .base_resource import BaseResource
+
+
+class WorkItemRelationDefinitions(BaseResource):
+    """API client for managing workspace-level work item relation definitions."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(
+        self,
+        workspace_slug: str,
+        is_default: bool | None = None,
+        is_active: bool | None = None,
+    ) -> list[WorkItemRelationDefinition]:
+        """List all work item relation definitions in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            is_default: Optional filter by default status
+            is_active: Optional filter by active status
+        """
+        params: dict[str, Any] = {}
+        if is_default is not None:
+            params["is_default"] = str(is_default).lower()
+        if is_active is not None:
+            params["is_active"] = str(is_active).lower()
+
+        response = self._get(
+            f"{workspace_slug}/work-item-relation-definitions/",
+            params=params if params else None,
+        )
+        return [WorkItemRelationDefinition.model_validate(item) for item in response]
+
+    def create(
+        self, workspace_slug: str, data: CreateWorkItemRelationDefinition
+    ) -> WorkItemRelationDefinition:
+        """Create a new work item relation definition in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Relation definition data
+        """
+        response = self._post(
+            f"{workspace_slug}/work-item-relation-definitions/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemRelationDefinition.model_validate(response)
+
+    def update(
+        self,
+        workspace_slug: str,
+        definition_id: str,
+        data: UpdateWorkItemRelationDefinition,
+    ) -> WorkItemRelationDefinition:
+        """Update a work item relation definition in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            definition_id: UUID of the relation definition
+            data: Updated relation definition data
+        """
+        response = self._patch(
+            f"{workspace_slug}/work-item-relation-definitions/{definition_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemRelationDefinition.model_validate(response)
+
+    def delete(self, workspace_slug: str, definition_id: str) -> None:
+        """Delete a work item relation definition in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            definition_id: UUID of the relation definition
+        """
+        return self._delete(
+            f"{workspace_slug}/work-item-relation-definitions/{definition_id}/"
+        )

--- a/plane/api/workspace_project_labels.py
+++ b/plane/api/workspace_project_labels.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from ..models.workspace_project_labels import (
+    CreateWorkspaceProjectLabel,
+    UpdateWorkspaceProjectLabel,
+    WorkspaceProjectLabel,
+)
+from .base_resource import BaseResource
+
+
+class WorkspaceProjectLabels(BaseResource):
+    """API client for managing workspace-level project labels."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[WorkspaceProjectLabel]:
+        """List all project labels in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/project-labels/")
+        return [WorkspaceProjectLabel.model_validate(item) for item in response]
+
+    def create(
+        self, workspace_slug: str, data: CreateWorkspaceProjectLabel
+    ) -> WorkspaceProjectLabel:
+        """Create a new project label in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Project label data
+        """
+        response = self._post(
+            f"{workspace_slug}/project-labels/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkspaceProjectLabel.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, label_id: str, data: UpdateWorkspaceProjectLabel
+    ) -> WorkspaceProjectLabel:
+        """Update a project label in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            label_id: UUID of the label
+            data: Updated label data
+        """
+        response = self._patch(
+            f"{workspace_slug}/project-labels/{label_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkspaceProjectLabel.model_validate(response)
+
+    def delete(self, workspace_slug: str, label_id: str) -> None:
+        """Delete a project label in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            label_id: UUID of the label
+        """
+        return self._delete(f"{workspace_slug}/project-labels/{label_id}/")

--- a/plane/api/workspace_project_states.py
+++ b/plane/api/workspace_project_states.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from ..models.workspace_project_states import (
+    CreateWorkspaceProjectState,
+    UpdateWorkspaceProjectState,
+    WorkspaceProjectState,
+)
+from .base_resource import BaseResource
+
+
+class WorkspaceProjectStates(BaseResource):
+    """API client for managing workspace-level project states."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[WorkspaceProjectState]:
+        """List all project states in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/project-states/")
+        return [WorkspaceProjectState.model_validate(item) for item in response]
+
+    def create(
+        self, workspace_slug: str, data: CreateWorkspaceProjectState
+    ) -> WorkspaceProjectState:
+        """Create a new project state in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Project state data
+        """
+        response = self._post(
+            f"{workspace_slug}/project-states/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkspaceProjectState.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, state_id: str, data: UpdateWorkspaceProjectState
+    ) -> WorkspaceProjectState:
+        """Update a project state in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            state_id: UUID of the state
+            data: Updated state data
+        """
+        response = self._patch(
+            f"{workspace_slug}/project-states/{state_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkspaceProjectState.model_validate(response)
+
+    def delete(self, workspace_slug: str, state_id: str) -> None:
+        """Delete a project state in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            state_id: UUID of the state
+        """
+        return self._delete(f"{workspace_slug}/project-states/{state_id}/")

--- a/plane/api/workspace_templates/__init__.py
+++ b/plane/api/workspace_templates/__init__.py
@@ -1,0 +1,3 @@
+from .base import WorkspaceTemplates
+
+__all__ = ["WorkspaceTemplates"]

--- a/plane/api/workspace_templates/base.py
+++ b/plane/api/workspace_templates/base.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from ..base_resource import BaseResource
+from .page_templates import WorkspacePageTemplates
+from .project_templates import WorkspaceProjectTemplates
+from .workitem_templates import WorkspaceWorkItemTemplates
+
+
+class WorkspaceTemplates(BaseResource):
+    """Container for workspace-level template sub-resources."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+        # Initialize sub-resources
+        self.work_items = WorkspaceWorkItemTemplates(config)
+        self.projects = WorkspaceProjectTemplates(config)
+        self.pages = WorkspacePageTemplates(config)

--- a/plane/api/workspace_templates/page_templates.py
+++ b/plane/api/workspace_templates/page_templates.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from ...models.workspace_templates import (
+    CreatePageTemplate,
+    PageTemplate,
+    UpdatePageTemplate,
+)
+from ..base_resource import BaseResource
+
+
+class WorkspacePageTemplates(BaseResource):
+    """API client for managing workspace-level page templates."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[PageTemplate]:
+        """List all page templates in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/pages/templates/")
+        return [PageTemplate.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreatePageTemplate) -> PageTemplate:
+        """Create a new page template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Page template data
+        """
+        response = self._post(
+            f"{workspace_slug}/pages/templates/",
+            data.model_dump(exclude_none=True),
+        )
+        return PageTemplate.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, template_id: str, data: UpdatePageTemplate
+    ) -> PageTemplate:
+        """Update a page template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+            data: Updated template data
+        """
+        response = self._patch(
+            f"{workspace_slug}/pages/templates/{template_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return PageTemplate.model_validate(response)
+
+    def delete(self, workspace_slug: str, template_id: str) -> None:
+        """Delete a page template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+        """
+        return self._delete(f"{workspace_slug}/pages/templates/{template_id}/")

--- a/plane/api/workspace_templates/project_templates.py
+++ b/plane/api/workspace_templates/project_templates.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from ...models.workspace_templates import (
+    CreateProjectTemplate,
+    ProjectTemplate,
+    UpdateProjectTemplate,
+)
+from ..base_resource import BaseResource
+
+
+class WorkspaceProjectTemplates(BaseResource):
+    """API client for managing workspace-level project templates."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[ProjectTemplate]:
+        """List all project templates in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/projects/templates/")
+        return [ProjectTemplate.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateProjectTemplate) -> ProjectTemplate:
+        """Create a new project template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Project template data
+        """
+        response = self._post(
+            f"{workspace_slug}/projects/templates/",
+            data.model_dump(exclude_none=True),
+        )
+        return ProjectTemplate.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, template_id: str, data: UpdateProjectTemplate
+    ) -> ProjectTemplate:
+        """Update a project template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+            data: Updated template data
+        """
+        response = self._patch(
+            f"{workspace_slug}/projects/templates/{template_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return ProjectTemplate.model_validate(response)
+
+    def delete(self, workspace_slug: str, template_id: str) -> None:
+        """Delete a project template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+        """
+        return self._delete(f"{workspace_slug}/projects/templates/{template_id}/")

--- a/plane/api/workspace_templates/workitem_templates.py
+++ b/plane/api/workspace_templates/workitem_templates.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from ...models.workspace_templates import (
+    CreateWorkItemTemplate,
+    UpdateWorkItemTemplate,
+    WorkItemTemplate,
+)
+from ..base_resource import BaseResource
+
+
+class WorkspaceWorkItemTemplates(BaseResource):
+    """API client for managing workspace-level work item templates."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str) -> list[WorkItemTemplate]:
+        """List all work item templates in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/workitems/templates/")
+        return [WorkItemTemplate.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateWorkItemTemplate) -> WorkItemTemplate:
+        """Create a new work item template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Work item template data
+        """
+        response = self._post(
+            f"{workspace_slug}/workitems/templates/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemTemplate.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, template_id: str, data: UpdateWorkItemTemplate
+    ) -> WorkItemTemplate:
+        """Update a work item template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+            data: Updated template data
+        """
+        response = self._patch(
+            f"{workspace_slug}/workitems/templates/{template_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemTemplate.model_validate(response)
+
+    def delete(self, workspace_slug: str, template_id: str) -> None:
+        """Delete a work item template in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            template_id: UUID of the template
+        """
+        return self._delete(f"{workspace_slug}/workitems/templates/{template_id}/")

--- a/plane/api/workspace_work_item_properties/__init__.py
+++ b/plane/api/workspace_work_item_properties/__init__.py
@@ -1,0 +1,3 @@
+from .base import WorkspaceWorkItemProperties
+
+__all__ = ["WorkspaceWorkItemProperties"]

--- a/plane/api/workspace_work_item_properties/base.py
+++ b/plane/api/workspace_work_item_properties/base.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+from ...models.work_item_properties import (
+    CreateWorkItemProperty,
+    UpdateWorkItemProperty,
+    WorkItemProperty,
+)
+from ..base_resource import BaseResource
+from .options import WorkspaceWorkItemPropertyOptions
+
+
+class WorkspaceWorkItemProperties(BaseResource):
+    """API client for managing workspace-level work item properties."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+        # Initialize sub-resources
+        self.options = WorkspaceWorkItemPropertyOptions(config)
+
+    def list(self, workspace_slug: str) -> list[WorkItemProperty]:
+        """List all work item properties in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/work-item-properties/")
+        return [WorkItemProperty.model_validate(item) for item in response]
+
+    def create(
+        self, workspace_slug: str, data: CreateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Create a new work item property in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Work item property data
+        """
+        response = self._post(
+            f"{workspace_slug}/work-item-properties/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, property_id: str, data: UpdateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Update a work item property in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            data: Updated property data
+        """
+        response = self._patch(
+            f"{workspace_slug}/work-item-properties/{property_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def delete(self, workspace_slug: str, property_id: str) -> None:
+        """Delete a work item property in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+        """
+        return self._delete(f"{workspace_slug}/work-item-properties/{property_id}/")

--- a/plane/api/workspace_work_item_properties/options.py
+++ b/plane/api/workspace_work_item_properties/options.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from ...models.work_item_properties import (
+    CreateWorkItemPropertyOption,
+    UpdateWorkItemPropertyOption,
+    WorkItemPropertyOption,
+)
+from ..base_resource import BaseResource
+
+
+class WorkspaceWorkItemPropertyOptions(BaseResource):
+    """API client for managing options on workspace-level work item properties."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str, property_id: str) -> list[WorkItemPropertyOption]:
+        """List options for a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+        """
+        response = self._get(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/"
+        )
+        return [WorkItemPropertyOption.model_validate(item) for item in response]
+
+    def create(
+        self,
+        workspace_slug: str,
+        property_id: str,
+        data: CreateWorkItemPropertyOption,
+    ) -> WorkItemPropertyOption:
+        """Create a new option for a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            data: Option data
+        """
+        response = self._post(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemPropertyOption.model_validate(response)
+
+    def update(
+        self,
+        workspace_slug: str,
+        property_id: str,
+        option_id: str,
+        data: UpdateWorkItemPropertyOption,
+    ) -> WorkItemPropertyOption:
+        """Update an option for a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            option_id: UUID of the option
+            data: Updated option data
+        """
+        response = self._patch(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemPropertyOption.model_validate(response)

--- a/plane/api/workspace_work_item_types/__init__.py
+++ b/plane/api/workspace_work_item_types/__init__.py
@@ -1,0 +1,3 @@
+from .base import WorkspaceWorkItemTypes
+
+__all__ = ["WorkspaceWorkItemTypes"]

--- a/plane/api/workspace_work_item_types/base.py
+++ b/plane/api/workspace_work_item_types/base.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from ...models.work_item_types import CreateWorkItemType, UpdateWorkItemType, WorkItemType
+from ..base_resource import BaseResource
+from .properties import WorkspaceWorkItemTypeProperties
+
+
+class WorkspaceWorkItemTypes(BaseResource):
+    """API client for managing workspace-level work item types."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+        # Initialize sub-resources
+        self.properties = WorkspaceWorkItemTypeProperties(config)
+
+    def list(self, workspace_slug: str) -> list[WorkItemType]:
+        """List all work item types in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/work-item-types/")
+        return [WorkItemType.model_validate(item) for item in response]
+
+    def create(self, workspace_slug: str, data: CreateWorkItemType) -> WorkItemType:
+        """Create a new work item type in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            data: Work item type data
+        """
+        response = self._post(
+            f"{workspace_slug}/work-item-types/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemType.model_validate(response)
+
+    def update(
+        self, workspace_slug: str, type_id: str, data: UpdateWorkItemType
+    ) -> WorkItemType:
+        """Update a work item type in the workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+            data: Updated work item type data
+        """
+        response = self._patch(
+            f"{workspace_slug}/work-item-types/{type_id}/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemType.model_validate(response)

--- a/plane/api/workspace_work_item_types/properties.py
+++ b/plane/api/workspace_work_item_types/properties.py
@@ -23,24 +23,23 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
         )
         return [WorkItemProperty.model_validate(item) for item in response]
 
-    def link(
-        self, workspace_slug: str, type_id: str, property_id: str
+    def create(
+        self, workspace_slug: str, type_id: str, data: WorkspaceWorkItemTypePropertyLink
     ) -> WorkItemProperty:
         """Link a property to a workspace work item type.
 
         Args:
             workspace_slug: The workspace slug identifier
             type_id: UUID of the work item type
-            property_id: UUID of the property to link
+            data: DTO containing the property_id to link
         """
-        data = WorkspaceWorkItemTypePropertyLink(property_id=property_id)
         response = self._post(
             f"{workspace_slug}/work-item-types/{type_id}/properties/",
             data.model_dump(exclude_none=True),
         )
         return WorkItemProperty.model_validate(response)
 
-    def unlink(self, workspace_slug: str, type_id: str, property_id: str) -> None:
+    def delete(self, workspace_slug: str, type_id: str, property_id: str) -> None:
         """Unlink a property from a workspace work item type.
 
         Args:

--- a/plane/api/workspace_work_item_types/properties.py
+++ b/plane/api/workspace_work_item_types/properties.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from ...models.work_item_properties import WorkItemProperty
+from ...models.work_item_types import WorkspaceWorkItemTypePropertyLink
+from ..base_resource import BaseResource
+
+
+class WorkspaceWorkItemTypeProperties(BaseResource):
+    """API client for managing property links on workspace-level work item types."""
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    def list(self, workspace_slug: str, type_id: str) -> list[WorkItemProperty]:
+        """List properties linked to a workspace work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+        """
+        response = self._get(
+            f"{workspace_slug}/work-item-types/{type_id}/properties/"
+        )
+        return [WorkItemProperty.model_validate(item) for item in response]
+
+    def link(
+        self, workspace_slug: str, type_id: str, property_id: str
+    ) -> WorkItemProperty:
+        """Link a property to a workspace work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+            property_id: UUID of the property to link
+        """
+        data = WorkspaceWorkItemTypePropertyLink(property_id=property_id)
+        response = self._post(
+            f"{workspace_slug}/work-item-types/{type_id}/properties/",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def unlink(self, workspace_slug: str, type_id: str, property_id: str) -> None:
+        """Unlink a property from a workspace work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+            property_id: UUID of the property to unlink
+        """
+        return self._delete(
+            f"{workspace_slug}/work-item-types/{type_id}/properties/{property_id}/"
+        )

--- a/plane/client/plane_client.py
+++ b/plane/client/plane_client.py
@@ -10,13 +10,20 @@ from ..api.milestones import Milestones
 from ..api.modules import Modules
 from ..api.pages import Pages
 from ..api.projects import Projects
+from ..api.releases import Releases
 from ..api.states import States
 from ..api.stickies import Stickies
 from ..api.teamspaces import Teamspaces
 from ..api.users import Users
 from ..api.work_item_properties import WorkItemProperties
+from ..api.work_item_relation_definitions import WorkItemRelationDefinitions
 from ..api.work_item_types import WorkItemTypes
 from ..api.work_items import WorkItems
+from ..api.workspace_project_labels import WorkspaceProjectLabels
+from ..api.workspace_project_states import WorkspaceProjectStates
+from ..api.workspace_templates import WorkspaceTemplates
+from ..api.workspace_work_item_properties import WorkspaceWorkItemProperties
+from ..api.workspace_work_item_types import WorkspaceWorkItemTypes
 from ..api.workspaces import Workspaces
 from ..config import Configuration
 from ..errors import ConfigurationError
@@ -65,4 +72,11 @@ class PlaneClient:
         self.stickies = Stickies(self.config)
         self.initiatives = Initiatives(self.config)
         self.teamspaces = Teamspaces(self.config)
+        self.workspace_templates = WorkspaceTemplates(self.config)
+        self.workspace_work_item_types = WorkspaceWorkItemTypes(self.config)
+        self.workspace_work_item_properties = WorkspaceWorkItemProperties(self.config)
+        self.workspace_project_labels = WorkspaceProjectLabels(self.config)
+        self.workspace_project_states = WorkspaceProjectStates(self.config)
+        self.work_item_relation_definitions = WorkItemRelationDefinitions(self.config)
+        self.releases = Releases(self.config)
 

--- a/plane/models/releases.py
+++ b/plane/models/releases.py
@@ -1,0 +1,98 @@
+"""Models for releases."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Release(BaseModel):
+    """Release response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    start_date: str | None = None
+    release_date: str | None = None
+    status: str | None = None
+    logo_props: Any | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateRelease(BaseModel):
+    """Request model for creating a release."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    description: str | None = None
+    start_date: str | None = None
+    release_date: str | None = None
+    status: str | None = None
+    logo_props: Any | None = None
+
+
+class UpdateRelease(BaseModel):
+    """Request model for updating a release."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    description: str | None = None
+    start_date: str | None = None
+    release_date: str | None = None
+    status: str | None = None
+    logo_props: Any | None = None
+
+
+class ReleaseTag(BaseModel):
+    """Release tag response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    color: str | None = None
+    sort_order: float | None = None
+    workspace: str | None = None
+
+
+class CreateReleaseTag(BaseModel):
+    """Request model for creating a release tag."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    color: str | None = None
+
+
+class ReleaseLabel(BaseModel):
+    """Release label response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    color: str | None = None
+    sort_order: float | None = None
+    workspace: str | None = None
+
+
+class CreateReleaseLabel(BaseModel):
+    """Request model for creating a release label."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    color: str | None = None
+
+
+class AddReleaseItemLabel(BaseModel):
+    """Request model for adding labels to a release item."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    label_ids: list[str]

--- a/plane/models/work_item_relation_definitions.py
+++ b/plane/models/work_item_relation_definitions.py
@@ -1,0 +1,49 @@
+"""Models for work item relation definitions."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkItemRelationDefinition(BaseModel):
+    """Work item relation definition response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    outward: str | None = None
+    inward: str | None = None
+    is_default: bool | None = None
+    is_active: bool | None = None
+    color: str | None = None
+    sort_order: float | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateWorkItemRelationDefinition(BaseModel):
+    """Request model for creating a work item relation definition."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    outward: str | None = None
+    inward: str | None = None
+    is_default: bool | None = None
+    is_active: bool | None = None
+    color: str | None = None
+    sort_order: float | None = None
+
+
+class UpdateWorkItemRelationDefinition(BaseModel):
+    """Request model for updating a work item relation definition."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    outward: str | None = None
+    inward: str | None = None
+    is_default: bool | None = None
+    is_active: bool | None = None
+    color: str | None = None
+    sort_order: float | None = None

--- a/plane/models/work_item_types.py
+++ b/plane/models/work_item_types.py
@@ -35,6 +35,7 @@ class CreateWorkItemType(BaseModel):
     project_ids: list[str] | None = None
     name: str
     description: str | None = None
+    logo_props: Any | None = None
     is_epic: bool | None = None
     is_active: bool | None = None
     external_source: str | None = None
@@ -49,7 +50,16 @@ class UpdateWorkItemType(BaseModel):
     project_ids: list[str] | None = None
     name: str | None = None
     description: str | None = None
+    logo_props: Any | None = None
     is_epic: bool | None = None
     is_active: bool | None = None
     external_source: str | None = None
     external_id: str | None = None
+
+
+class WorkspaceWorkItemTypePropertyLink(BaseModel):
+    """Request model for linking a property to a workspace work item type."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    property_id: str

--- a/plane/models/workspace_project_labels.py
+++ b/plane/models/workspace_project_labels.py
@@ -1,0 +1,37 @@
+"""Models for workspace project labels."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkspaceProjectLabel(BaseModel):
+    """Workspace project label response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    color: str | None = None
+    sort_order: float | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateWorkspaceProjectLabel(BaseModel):
+    """Request model for creating a workspace project label."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    color: str | None = None
+    sort_order: float | None = None
+
+
+class UpdateWorkspaceProjectLabel(BaseModel):
+    """Request model for updating a workspace project label."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    color: str | None = None
+    sort_order: float | None = None

--- a/plane/models/workspace_project_states.py
+++ b/plane/models/workspace_project_states.py
@@ -1,0 +1,46 @@
+"""Models for workspace project states."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkspaceProjectState(BaseModel):
+    """Workspace project state response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    color: str | None = None
+    group: str | None = None
+    sequence: float | None = None
+    default: bool | None = None
+    description: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateWorkspaceProjectState(BaseModel):
+    """Request model for creating a workspace project state."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    color: str | None = None
+    group: str | None = None
+    sequence: float | None = None
+    default: bool | None = None
+    description: str | None = None
+
+
+class UpdateWorkspaceProjectState(BaseModel):
+    """Request model for updating a workspace project state."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    color: str | None = None
+    group: str | None = None
+    sequence: float | None = None
+    default: bool | None = None
+    description: str | None = None

--- a/plane/models/workspace_templates.py
+++ b/plane/models/workspace_templates.py
@@ -1,0 +1,126 @@
+"""Models for workspace-level templates.
+
+Work item and page template models are reused from project_templates.
+This module provides project template models which are workspace-specific.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkItemTemplate(BaseModel):
+    """Workspace work item template response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateWorkItemTemplate(BaseModel):
+    """Request model for creating a workspace work item template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None
+
+
+class UpdateWorkItemTemplate(BaseModel):
+    """Request model for updating a workspace work item template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None
+
+
+class ProjectTemplate(BaseModel):
+    """Workspace project template response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    logo_props: Any | None = None
+    template_data: Any | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreateProjectTemplate(BaseModel):
+    """Request model for creating a workspace project template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    description: str | None = None
+    logo_props: Any | None = None
+    template_data: Any | None = None
+
+
+class UpdateProjectTemplate(BaseModel):
+    """Request model for updating a workspace project template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    description: str | None = None
+    logo_props: Any | None = None
+    template_data: Any | None = None
+
+
+class PageTemplate(BaseModel):
+    """Workspace page template response model."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    workspace: str | None = None
+
+
+class CreatePageTemplate(BaseModel):
+    """Request model for creating a workspace page template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None
+
+
+class UpdatePageTemplate(BaseModel):
+    """Request model for updating a workspace page template."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    name: str | None = None
+    description: str | None = None
+    description_html: str | None = None
+    template_data: Any | None = None
+    logo_props: Any | None = None

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -1,6 +1,5 @@
 """Unit tests for Releases API resource (smoke tests with real HTTP requests)."""
 
-import warnings
 from uuid import uuid4
 
 import pytest
@@ -34,16 +33,13 @@ class TestReleases:
         assert created.id is not None
         assert created.name == name
 
-        try:
-            updated = client.releases.update(
-                workspace_slug,
-                created.id,
-                UpdateRelease(description="Updated release description"),
-            )
-            assert updated.id == created.id
-            assert updated.description == "Updated release description"
-        except Exception as exc:
-            warnings.warn(f"Update failed for release {created.id}: {exc}", stacklevel=1)
+        updated = client.releases.update(
+            workspace_slug,
+            created.id,
+            UpdateRelease(description="Updated release description"),
+        )
+        assert updated.id == created.id
+        assert updated.description == "Updated release description"
 
 
 class TestReleaseTags:
@@ -94,6 +90,7 @@ class TestReleaseItemLabels:
             pytest.skip("No releases available to test item labels listing")
 
         release = releases[0]
+        assert release.id is not None
         labels = client.releases.item_labels.list(workspace_slug, release.id)
         assert isinstance(labels, list)
 
@@ -107,6 +104,7 @@ class TestReleaseItemLabels:
             workspace_slug, CreateRelease(name=release_name)
         )
         assert release is not None
+        assert release.id is not None
 
         # Create a label
         label_name = f"label-{uuid4().hex[:6]}"
@@ -114,17 +112,12 @@ class TestReleaseItemLabels:
             workspace_slug, CreateReleaseLabel(name=label_name)
         )
         assert label is not None
+        assert label.id is not None
 
-        try:
-            # Add label to release
-            add_data = AddReleaseItemLabel(label_ids=[label.id])
-            result = client.releases.item_labels.add(workspace_slug, release.id, add_data)
-            assert isinstance(result, list)
+        # Add label to release
+        add_data = AddReleaseItemLabel(label_ids=[label.id])
+        result = client.releases.item_labels.create(workspace_slug, release.id, add_data)
+        assert isinstance(result, list)
 
-            # Remove label from release
-            try:
-                client.releases.item_labels.remove(workspace_slug, release.id, label.id)
-            except Exception as exc:
-                warnings.warn(f"Remove label failed for release {release.id}: {exc}", stacklevel=1)
-        except Exception as exc:
-            warnings.warn(f"Add label failed for release {release.id}: {exc}", stacklevel=1)
+        # Remove label from release
+        client.releases.item_labels.delete(workspace_slug, release.id, label.id)

--- a/tests/unit/test_releases.py
+++ b/tests/unit/test_releases.py
@@ -1,0 +1,130 @@
+"""Unit tests for Releases API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+import pytest
+
+from plane.client import PlaneClient
+from plane.models.releases import (
+    AddReleaseItemLabel,
+    CreateRelease,
+    CreateReleaseLabel,
+    CreateReleaseTag,
+    UpdateRelease,
+)
+
+
+class TestReleases:
+    """Test Releases API resource."""
+
+    def test_list_releases(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Test listing releases."""
+        releases = client.releases.list(workspace_slug)
+        assert isinstance(releases, list)
+
+    def test_create_update_release(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating and updating a release."""
+        name = f"test-release-{uuid4().hex[:8]}"
+        data = CreateRelease(name=name, description="Test release", status="unreleased")
+        created = client.releases.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.releases.update(
+                workspace_slug,
+                created.id,
+                UpdateRelease(description="Updated release description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated release description"
+        except Exception as exc:
+            warnings.warn(f"Update failed for release {created.id}: {exc}", stacklevel=1)
+
+
+class TestReleaseTags:
+    """Test Releases.tags sub-resource."""
+
+    def test_list_release_tags(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Test listing release tags."""
+        tags = client.releases.tags.list(workspace_slug)
+        assert isinstance(tags, list)
+
+    def test_create_release_tag(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Test creating a release tag."""
+        name = f"tag-{uuid4().hex[:6]}"
+        data = CreateReleaseTag(name=name, color="#AABBCC")
+        created = client.releases.tags.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+
+class TestReleaseLabels:
+    """Test Releases.labels sub-resource."""
+
+    def test_list_release_labels(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Test listing release labels."""
+        labels = client.releases.labels.list(workspace_slug)
+        assert isinstance(labels, list)
+
+    def test_create_release_label(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Test creating a release label."""
+        name = f"label-{uuid4().hex[:6]}"
+        data = CreateReleaseLabel(name=name, color="#112233")
+        created = client.releases.labels.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+
+class TestReleaseItemLabels:
+    """Test Releases.item_labels sub-resource."""
+
+    def test_list_item_labels_for_release(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing labels for a specific release."""
+        releases = client.releases.list(workspace_slug)
+        if not releases:
+            pytest.skip("No releases available to test item labels listing")
+
+        release = releases[0]
+        labels = client.releases.item_labels.list(workspace_slug, release.id)
+        assert isinstance(labels, list)
+
+    def test_add_remove_label_to_release(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test adding and removing labels from a release."""
+        # Create a release
+        release_name = f"test-release-{uuid4().hex[:8]}"
+        release = client.releases.create(
+            workspace_slug, CreateRelease(name=release_name)
+        )
+        assert release is not None
+
+        # Create a label
+        label_name = f"label-{uuid4().hex[:6]}"
+        label = client.releases.labels.create(
+            workspace_slug, CreateReleaseLabel(name=label_name)
+        )
+        assert label is not None
+
+        try:
+            # Add label to release
+            add_data = AddReleaseItemLabel(label_ids=[label.id])
+            result = client.releases.item_labels.add(workspace_slug, release.id, add_data)
+            assert isinstance(result, list)
+
+            # Remove label from release
+            try:
+                client.releases.item_labels.remove(workspace_slug, release.id, label.id)
+            except Exception as exc:
+                warnings.warn(f"Remove label failed for release {release.id}: {exc}", stacklevel=1)
+        except Exception as exc:
+            warnings.warn(f"Add label failed for release {release.id}: {exc}", stacklevel=1)

--- a/tests/unit/test_work_item_relation_definitions.py
+++ b/tests/unit/test_work_item_relation_definitions.py
@@ -1,0 +1,62 @@
+"""Unit tests for WorkItemRelationDefinitions API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+from plane.client import PlaneClient
+from plane.models.work_item_relation_definitions import (
+    CreateWorkItemRelationDefinition,
+    UpdateWorkItemRelationDefinition,
+)
+
+
+class TestWorkItemRelationDefinitions:
+    """Test WorkItemRelationDefinitions API resource."""
+
+    def test_list_relation_definitions(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing work item relation definitions."""
+        definitions = client.work_item_relation_definitions.list(workspace_slug)
+        assert isinstance(definitions, list)
+
+    def test_list_relation_definitions_with_filters(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing relation definitions with is_default and is_active filters."""
+        filtered = client.work_item_relation_definitions.list(
+            workspace_slug, is_default=False, is_active=True
+        )
+        assert isinstance(filtered, list)
+
+    def test_create_update_delete_relation_definition(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating, updating, and deleting a work item relation definition."""
+        name = f"test-rel-{uuid4().hex[:8]}"
+        data = CreateWorkItemRelationDefinition(
+            name=name,
+            outward="blocks",
+            inward="is blocked by",
+            is_active=True,
+        )
+        created = client.work_item_relation_definitions.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.work_item_relation_definitions.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkItemRelationDefinition(outward="depends on"),
+            )
+            assert updated.id == created.id
+            assert updated.outward == "depends on"
+        finally:
+            try:
+                client.work_item_relation_definitions.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for relation definition {created.id}: {exc}", stacklevel=1
+                )

--- a/tests/unit/test_work_item_relation_definitions.py
+++ b/tests/unit/test_work_item_relation_definitions.py
@@ -4,6 +4,7 @@ import warnings
 from uuid import uuid4
 
 from plane.client import PlaneClient
+from plane.errors.errors import HttpError
 from plane.models.work_item_relation_definitions import (
     CreateWorkItemRelationDefinition,
     UpdateWorkItemRelationDefinition,
@@ -56,7 +57,7 @@ class TestWorkItemRelationDefinitions:
         finally:
             try:
                 client.work_item_relation_definitions.delete(workspace_slug, created.id)
-            except Exception as exc:
+            except HttpError as exc:
                 warnings.warn(
                     f"Teardown failed for relation definition {created.id}: {exc}", stacklevel=1
                 )

--- a/tests/unit/test_workspace_project_labels.py
+++ b/tests/unit/test_workspace_project_labels.py
@@ -1,0 +1,48 @@
+"""Unit tests for WorkspaceProjectLabels API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+from plane.client import PlaneClient
+from plane.models.workspace_project_labels import (
+    CreateWorkspaceProjectLabel,
+    UpdateWorkspaceProjectLabel,
+)
+
+
+class TestWorkspaceProjectLabels:
+    """Test WorkspaceProjectLabels API resource."""
+
+    def test_list_workspace_project_labels(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace project labels."""
+        labels = client.workspace_project_labels.list(workspace_slug)
+        assert isinstance(labels, list)
+
+    def test_create_update_delete_workspace_project_label(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating, updating, and deleting a workspace project label."""
+        name = f"test-label-{uuid4().hex[:8]}"
+        data = CreateWorkspaceProjectLabel(name=name, color="#FF6B6B")
+        created = client.workspace_project_labels.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_project_labels.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkspaceProjectLabel(color="#00FF00"),
+            )
+            assert updated.id == created.id
+            assert updated.color == "#00FF00"
+        finally:
+            try:
+                client.workspace_project_labels.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for workspace project label {created.id}: {exc}", stacklevel=1
+                )

--- a/tests/unit/test_workspace_project_states.py
+++ b/tests/unit/test_workspace_project_states.py
@@ -1,0 +1,53 @@
+"""Unit tests for WorkspaceProjectStates API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+from plane.client import PlaneClient
+from plane.models.workspace_project_states import (
+    CreateWorkspaceProjectState,
+    UpdateWorkspaceProjectState,
+)
+
+
+class TestWorkspaceProjectStates:
+    """Test WorkspaceProjectStates API resource."""
+
+    def test_list_workspace_project_states(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace project states."""
+        states = client.workspace_project_states.list(workspace_slug)
+        assert isinstance(states, list)
+
+    def test_create_update_delete_workspace_project_state(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating, updating, and deleting a workspace project state."""
+        name = f"test-state-{uuid4().hex[:8]}"
+        data = CreateWorkspaceProjectState(
+            name=name,
+            color="#FF0000",
+            group="unstarted",
+            description="Test workspace state",
+        )
+        created = client.workspace_project_states.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_project_states.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkspaceProjectState(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            try:
+                client.workspace_project_states.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for workspace project state {created.id}: {exc}", stacklevel=1
+                )

--- a/tests/unit/test_workspace_templates.py
+++ b/tests/unit/test_workspace_templates.py
@@ -4,6 +4,7 @@ import warnings
 from uuid import uuid4
 
 from plane.client import PlaneClient
+from plane.errors.errors import HttpError
 from plane.models.workspace_templates import (
     CreatePageTemplate,
     CreateProjectTemplate,
@@ -46,7 +47,7 @@ class TestWorkspaceWorkItemTemplates:
         finally:
             try:
                 client.workspace_templates.work_items.delete(workspace_slug, created.id)
-            except Exception as exc:
+            except HttpError as exc:
                 warnings.warn(
                     f"Teardown failed for work item template {created.id}: {exc}",
                     stacklevel=1,
@@ -85,7 +86,7 @@ class TestWorkspaceProjectTemplates:
         finally:
             try:
                 client.workspace_templates.projects.delete(workspace_slug, created.id)
-            except Exception as exc:
+            except HttpError as exc:
                 warnings.warn(
                     f"Teardown failed for project template {created.id}: {exc}",
                     stacklevel=1,
@@ -124,7 +125,7 @@ class TestWorkspacePageTemplates:
         finally:
             try:
                 client.workspace_templates.pages.delete(workspace_slug, created.id)
-            except Exception as exc:
+            except HttpError as exc:
                 warnings.warn(
                     f"Teardown failed for page template {created.id}: {exc}",
                     stacklevel=1,

--- a/tests/unit/test_workspace_templates.py
+++ b/tests/unit/test_workspace_templates.py
@@ -1,0 +1,131 @@
+"""Unit tests for WorkspaceTemplates API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+from plane.client import PlaneClient
+from plane.models.workspace_templates import (
+    CreatePageTemplate,
+    CreateProjectTemplate,
+    CreateWorkItemTemplate,
+    UpdatePageTemplate,
+    UpdateProjectTemplate,
+    UpdateWorkItemTemplate,
+)
+
+
+class TestWorkspaceWorkItemTemplates:
+    """Test WorkspaceTemplates.work_items sub-resource."""
+
+    def test_list_work_item_templates(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace work item templates."""
+        templates = client.workspace_templates.work_items.list(workspace_slug)
+        assert isinstance(templates, list)
+
+    def test_create_update_delete_work_item_template(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test create, update, and delete of a workspace work item template."""
+        name = f"test-wi-tpl-{uuid4().hex[:8]}"
+        data = CreateWorkItemTemplate(name=name, description="Test work item template")
+        created = client.workspace_templates.work_items.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_templates.work_items.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkItemTemplate(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            try:
+                client.workspace_templates.work_items.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for work item template {created.id}: {exc}",
+                    stacklevel=1,
+                )
+
+
+class TestWorkspaceProjectTemplates:
+    """Test WorkspaceTemplates.projects sub-resource."""
+
+    def test_list_project_templates(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace project templates."""
+        templates = client.workspace_templates.projects.list(workspace_slug)
+        assert isinstance(templates, list)
+
+    def test_create_update_delete_project_template(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test create, update, and delete of a workspace project template."""
+        name = f"test-proj-tpl-{uuid4().hex[:8]}"
+        data = CreateProjectTemplate(name=name, description="Test project template")
+        created = client.workspace_templates.projects.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_templates.projects.update(
+                workspace_slug,
+                created.id,
+                UpdateProjectTemplate(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            try:
+                client.workspace_templates.projects.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for project template {created.id}: {exc}",
+                    stacklevel=1,
+                )
+
+
+class TestWorkspacePageTemplates:
+    """Test WorkspaceTemplates.pages sub-resource."""
+
+    def test_list_page_templates(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace page templates."""
+        templates = client.workspace_templates.pages.list(workspace_slug)
+        assert isinstance(templates, list)
+
+    def test_create_update_delete_page_template(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test create, update, and delete of a workspace page template."""
+        name = f"test-page-tpl-{uuid4().hex[:8]}"
+        data = CreatePageTemplate(name=name, description="Test page template")
+        created = client.workspace_templates.pages.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_templates.pages.update(
+                workspace_slug,
+                created.id,
+                UpdatePageTemplate(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            try:
+                client.workspace_templates.pages.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for page template {created.id}: {exc}",
+                    stacklevel=1,
+                )

--- a/tests/unit/test_workspace_work_item_properties.py
+++ b/tests/unit/test_workspace_work_item_properties.py
@@ -1,0 +1,121 @@
+"""Unit tests for WorkspaceWorkItemProperties API resource (smoke tests with real HTTP requests)."""
+
+import warnings
+from uuid import uuid4
+
+import pytest
+
+from plane.client import PlaneClient
+from plane.models.enums import PropertyType
+from plane.models.work_item_properties import (
+    CreateWorkItemProperty,
+    CreateWorkItemPropertyOption,
+    UpdateWorkItemProperty,
+    UpdateWorkItemPropertyOption,
+)
+from plane.models.work_item_property_configurations import TextAttributeSettings
+
+
+class TestWorkspaceWorkItemProperties:
+    """Test WorkspaceWorkItemProperties API resource."""
+
+    def test_list_workspace_work_item_properties(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace-level work item properties."""
+        props = client.workspace_work_item_properties.list(workspace_slug)
+        assert isinstance(props, list)
+
+    def test_create_update_delete_workspace_property(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating, updating, and deleting a workspace work item property."""
+        display_name = f"test-prop-{uuid4().hex[:8]}"
+        data = CreateWorkItemProperty(
+            display_name=display_name,
+            description="Test workspace property",
+            property_type=PropertyType.TEXT,
+            is_active=True,
+            settings=TextAttributeSettings(display_format="multi-line"),
+        )
+        created = client.workspace_work_item_properties.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.display_name == display_name
+
+        try:
+            updated = client.workspace_work_item_properties.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkItemProperty(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            try:
+                client.workspace_work_item_properties.delete(workspace_slug, created.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for workspace property {created.id}: {exc}", stacklevel=1
+                )
+
+
+class TestWorkspaceWorkItemPropertyOptions:
+    """Test WorkspaceWorkItemProperties.options sub-resource."""
+
+    def test_list_options_for_workspace_property(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing options for a workspace work item property."""
+        props = client.workspace_work_item_properties.list(workspace_slug)
+        option_props = [
+            p for p in props if getattr(p, "property_type", None) == PropertyType.OPTION
+        ]
+        if not option_props:
+            pytest.skip("No OPTION-type workspace properties available to test options listing")
+
+        prop = option_props[0]
+        options = client.workspace_work_item_properties.options.list(workspace_slug, prop.id)
+        assert isinstance(options, list)
+
+    def test_create_update_option_for_workspace_property(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating and updating an option for a workspace work item property."""
+        display_name = f"test-opt-prop-{uuid4().hex[:8]}"
+        prop_data = CreateWorkItemProperty(
+            display_name=display_name,
+            description="Test option property",
+            property_type=PropertyType.OPTION,
+            is_active=True,
+        )
+        prop = client.workspace_work_item_properties.create(workspace_slug, prop_data)
+        assert prop is not None
+
+        try:
+            option_name = f"opt-{uuid4().hex[:6]}"
+            opt = client.workspace_work_item_properties.options.create(
+                workspace_slug,
+                prop.id,
+                CreateWorkItemPropertyOption(name=option_name),
+            )
+            assert opt is not None
+            assert opt.id is not None
+            assert opt.name == option_name
+
+            updated_opt = client.workspace_work_item_properties.options.update(
+                workspace_slug,
+                prop.id,
+                opt.id,
+                UpdateWorkItemPropertyOption(name=f"{option_name}-updated"),
+            )
+            assert updated_opt.id == opt.id
+            assert updated_opt.name == f"{option_name}-updated"
+        finally:
+            try:
+                client.workspace_work_item_properties.delete(workspace_slug, prop.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for workspace property {prop.id}: {exc}",
+                    stacklevel=1,
+                )

--- a/tests/unit/test_workspace_work_item_types.py
+++ b/tests/unit/test_workspace_work_item_types.py
@@ -1,11 +1,17 @@
 """Unit tests for WorkspaceWorkItemTypes API resource (smoke tests with real HTTP requests)."""
 
+import warnings
 from uuid import uuid4
 
 import pytest
 
 from plane.client import PlaneClient
-from plane.models.work_item_types import CreateWorkItemType, UpdateWorkItemType
+from plane.errors.errors import HttpError
+from plane.models.work_item_types import (
+    CreateWorkItemType,
+    UpdateWorkItemType,
+    WorkspaceWorkItemTypePropertyLink,
+)
 
 
 class TestWorkspaceWorkItemTypes:
@@ -54,5 +60,46 @@ class TestWorkspaceWorkItemTypeProperties:
             pytest.skip("No workspace work item types available to test properties listing")
 
         wit = types[0]
+        assert wit.id is not None, f"Expected work item type to have an id, got: {wit}"
         props = client.workspace_work_item_types.properties.list(workspace_slug, wit.id)
         assert isinstance(props, list)
+
+    def test_create_delete_property_link(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test linking and unlinking a property on a workspace work item type."""
+        types = client.workspace_work_item_types.list(workspace_slug)
+        if not types:
+            pytest.skip("No workspace work item types available to test property link/unlink")
+
+        props = client.workspace_work_item_properties.list(workspace_slug)
+        if not props:
+            pytest.skip("No workspace work item properties available to link")
+
+        wit = types[0]
+        assert wit.id is not None
+
+        prop = props[0]
+        assert prop.id is not None
+
+        data = WorkspaceWorkItemTypePropertyLink(property_id=prop.id)
+        try:
+            linked = client.workspace_work_item_types.properties.create(
+                workspace_slug, wit.id, data
+            )
+            assert linked is not None
+
+            current = client.workspace_work_item_types.properties.list(
+                workspace_slug, wit.id
+            )
+            linked_ids = [p.id for p in current]
+            assert prop.id in linked_ids
+
+            client.workspace_work_item_types.properties.delete(
+                workspace_slug, wit.id, prop.id
+            )
+        except HttpError as exc:
+            warnings.warn(
+                f"Property link/unlink lifecycle failed for WIT {wit.id}: {exc}",
+                stacklevel=1,
+            )

--- a/tests/unit/test_workspace_work_item_types.py
+++ b/tests/unit/test_workspace_work_item_types.py
@@ -1,12 +1,10 @@
 """Unit tests for WorkspaceWorkItemTypes API resource (smoke tests with real HTTP requests)."""
 
-import warnings
 from uuid import uuid4
 
 import pytest
 
 from plane.client import PlaneClient
-from plane.errors.errors import HttpError
 from plane.models.work_item_types import (
     CreateWorkItemType,
     UpdateWorkItemType,
@@ -35,17 +33,14 @@ class TestWorkspaceWorkItemTypes:
         assert created.id is not None
         assert created.name == name
 
-        try:
-            updated = client.workspace_work_item_types.update(
-                workspace_slug,
-                created.id,
-                UpdateWorkItemType(description="Updated description"),
-            )
-            assert updated.id == created.id
-            assert updated.description == "Updated description"
-        finally:
-            # No delete endpoint on workspace WITs per spec — log a warning if needed
-            pass
+        updated = client.workspace_work_item_types.update(
+            workspace_slug,
+            created.id,
+            UpdateWorkItemType(description="Updated description"),
+        )
+        assert updated.id == created.id
+        assert updated.description == "Updated description"
+        # No delete endpoint on workspace WITs per spec.
 
 
 class TestWorkspaceWorkItemTypeProperties:
@@ -83,23 +78,13 @@ class TestWorkspaceWorkItemTypeProperties:
         assert prop.id is not None
 
         data = WorkspaceWorkItemTypePropertyLink(property_id=prop.id)
-        try:
-            linked = client.workspace_work_item_types.properties.create(
-                workspace_slug, wit.id, data
-            )
-            assert linked is not None
+        linked = client.workspace_work_item_types.properties.create(
+            workspace_slug, wit.id, data
+        )
+        assert linked is not None
 
-            current = client.workspace_work_item_types.properties.list(
-                workspace_slug, wit.id
-            )
-            linked_ids = [p.id for p in current]
-            assert prop.id in linked_ids
+        current = client.workspace_work_item_types.properties.list(workspace_slug, wit.id)
+        linked_ids = [p.id for p in current]
+        assert prop.id in linked_ids
 
-            client.workspace_work_item_types.properties.delete(
-                workspace_slug, wit.id, prop.id
-            )
-        except HttpError as exc:
-            warnings.warn(
-                f"Property link/unlink lifecycle failed for WIT {wit.id}: {exc}",
-                stacklevel=1,
-            )
+        client.workspace_work_item_types.properties.delete(workspace_slug, wit.id, prop.id)

--- a/tests/unit/test_workspace_work_item_types.py
+++ b/tests/unit/test_workspace_work_item_types.py
@@ -1,0 +1,58 @@
+"""Unit tests for WorkspaceWorkItemTypes API resource (smoke tests with real HTTP requests)."""
+
+from uuid import uuid4
+
+import pytest
+
+from plane.client import PlaneClient
+from plane.models.work_item_types import CreateWorkItemType, UpdateWorkItemType
+
+
+class TestWorkspaceWorkItemTypes:
+    """Test WorkspaceWorkItemTypes API resource."""
+
+    def test_list_workspace_work_item_types(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing workspace-level work item types."""
+        types = client.workspace_work_item_types.list(workspace_slug)
+        assert isinstance(types, list)
+
+    def test_create_update_workspace_work_item_type(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test creating and updating a workspace-level work item type."""
+        name = f"test-wit-{uuid4().hex[:8]}"
+        data = CreateWorkItemType(name=name, description="Test workspace WIT", is_active=True)
+        created = client.workspace_work_item_types.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+        assert created.name == name
+
+        try:
+            updated = client.workspace_work_item_types.update(
+                workspace_slug,
+                created.id,
+                UpdateWorkItemType(description="Updated description"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated description"
+        finally:
+            # No delete endpoint on workspace WITs per spec — log a warning if needed
+            pass
+
+
+class TestWorkspaceWorkItemTypeProperties:
+    """Test WorkspaceWorkItemTypes.properties sub-resource."""
+
+    def test_list_properties_for_workspace_wit(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing properties for a workspace work item type."""
+        types = client.workspace_work_item_types.list(workspace_slug)
+        if not types:
+            pytest.skip("No workspace work item types available to test properties listing")
+
+        wit = types[0]
+        props = client.workspace_work_item_types.properties.list(workspace_slug, wit.id)
+        assert isinstance(props, list)


### PR DESCRIPTION
## Summary

- Add `WorkspaceTemplates` resource with `work_items`, `projects`, and `pages` sub-resources — list/create/update/delete at `/workspaces/{slug}/workitems|projects|pages/templates/`
- Add `WorkspaceWorkItemTypes` resource (list/create/update) with `WorkspaceWorkItemTypeProperties` sub-resource for linking/unlinking properties
- Add `WorkspaceWorkItemProperties` resource (list/create/update/delete) with `WorkspaceWorkItemPropertyOptions` sub-resource (list/create/update)
- Add `WorkspaceProjectLabels` resource (list/create/update/delete)
- Add `WorkspaceProjectStates` resource (list/create/update/delete)
- Add `WorkItemRelationDefinitions` resource with optional `is_default`/`is_active` query filters (list/create/update/delete)
- Add `Releases` resource (list/create/update) with `ReleaseTags`, `ReleaseLabels`, and `ReleaseItemLabels` sub-resources
- All resources extend `BaseResource`, registered on `PlaneClient`, exported from `plane/__init__.py`
- 7 new unit test files (176 total tests — 6 passed, 170 skipped pending live credentials)

## Test plan

- [ ] `tests/unit/test_workspace_templates.py` — list/create/update/delete for workitem, project, page templates
- [ ] `tests/unit/test_workspace_work_item_types.py` — list/create/update + property link/unlink
- [ ] `tests/unit/test_workspace_work_item_properties.py` — CRUD + options sub-resource
- [ ] `tests/unit/test_workspace_project_labels.py` — CRUD
- [ ] `tests/unit/test_workspace_project_states.py` — CRUD
- [ ] `tests/unit/test_work_item_relation_definitions.py` — list with filters + CRUD
- [ ] `tests/unit/test_releases.py` — CRUD + tags/labels/item-labels sub-resources

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace release management: create, list, update releases with tags and labels.
  * Work item relation definitions management.
  * Workspace project labels and project states management.
  * Workspace templates for work items, projects, and pages.
  * Workspace work item properties and types management.
  * SDK client expanded to surface all new workspace and release APIs.

* **Tests**
  * Added integration-style tests covering new release, workspace, template, property, type, and relation APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane-python-sdk/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->