### PR TITLE
feat: complete workspace/project property APIs and fix endpoint URLs

### DIFF
--- a/plane/api/work_item_properties/base.py
+++ b/plane/api/work_item_properties/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any
 
@@ -90,6 +92,119 @@ class WorkItemProperties(BaseResource):
             f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/work-item-properties/{work_item_property_id}"
         )
 
+    def list_project(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> list[WorkItemProperty]:
+        """List all work item properties for a project regardless of work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            params: Optional query parameters
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties",
+            params=params,
+        )
+        return [WorkItemProperty.model_validate(item) for item in response]
+
+    def create_project(
+        self, workspace_slug: str, project_id: str, data: CreateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Create a project-level work item property (not linked to a specific type).
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            data: Work item property data
+        """
+        response = self._post(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def retrieve_project(
+        self, workspace_slug: str, project_id: str, property_id: str
+    ) -> WorkItemProperty:
+        """Retrieve a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}"
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def update_project(
+        self, workspace_slug: str, project_id: str, property_id: str, data: UpdateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Update a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+            data: Updated property data
+        """
+        response = self._patch(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def delete_project(
+        self, workspace_slug: str, project_id: str, property_id: str
+    ) -> None:
+        """Delete a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+        """
+        return self._delete(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}"
+        )
+
+    def attach_to_type(
+        self, workspace_slug: str, project_id: str, type_id: str, property_ids: list[str]
+    ) -> list[str]:
+        """Attach existing project-level properties to a work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            type_id: UUID of the work item type
+            property_ids: List of property UUIDs to attach
+        """
+        response = self._post(
+            f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/properties",
+            {"properties": property_ids},
+        )
+        return response.get("properties", [])
+
+    def detach_from_type(
+        self, workspace_slug: str, project_id: str, type_id: str, property_id: str
+    ) -> None:
+        """Detach a property from a work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            type_id: UUID of the work item type
+            property_id: UUID of the property to detach
+        """
+        return self._delete(
+            f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/properties/{property_id}"
+        )
+
     def list(
         self,
         workspace_slug: str,
@@ -97,7 +212,7 @@ class WorkItemProperties(BaseResource):
         type_id: str,
         params: Mapping[str, Any] | None = None,
     ) -> list[WorkItemProperty]:
-        """List work item properties with optional filtering parameters.
+        """List project-level work item properties for a type.
 
         Args:
             workspace_slug: The workspace slug identifier
@@ -110,3 +225,4 @@ class WorkItemProperties(BaseResource):
             params=params,
         )
         return [WorkItemProperty.model_validate(item) for item in response]
+

--- a/plane/api/work_items/base.py
+++ b/plane/api/work_items/base.py
@@ -177,6 +177,23 @@ class WorkItems(BaseResource):
         )
         return PaginatedWorkItemResponse.model_validate(response)
 
+    def list_workspace(
+        self,
+        workspace_slug: str,
+        params: WorkItemQueryParams | None = None,
+    ) -> PaginatedWorkItemResponse:
+        """List work items across the entire workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            params: Optional query parameters for filtering, ordering, and pagination
+        """
+        query_params = params.model_dump(exclude_none=True) if params else None
+        response = self._get(
+            f"{workspace_slug}/work-items", params=query_params
+        )
+        return PaginatedWorkItemResponse.model_validate(response)
+
     def search(
         self,
         workspace_slug: str,

--- a/plane/api/workspace_work_item_properties/base.py
+++ b/plane/api/workspace_work_item_properties/base.py
@@ -24,7 +24,7 @@ class WorkspaceWorkItemProperties(BaseResource):
         Args:
             workspace_slug: The workspace slug identifier
         """
-        response = self._get(f"{workspace_slug}/work-item-properties/")
+        response = self._get(f"{workspace_slug}/work-item-properties")
         return [WorkItemProperty.model_validate(item) for item in response]
 
     def create(
@@ -37,7 +37,7 @@ class WorkspaceWorkItemProperties(BaseResource):
             data: Work item property data
         """
         response = self._post(
-            f"{workspace_slug}/work-item-properties/",
+            f"{workspace_slug}/work-item-properties",
             data.model_dump(exclude_none=True),
         )
         return WorkItemProperty.model_validate(response)
@@ -53,9 +53,19 @@ class WorkspaceWorkItemProperties(BaseResource):
             data: Updated property data
         """
         response = self._patch(
-            f"{workspace_slug}/work-item-properties/{property_id}/",
+            f"{workspace_slug}/work-item-properties/{property_id}",
             data.model_dump(exclude_none=True),
         )
+        return WorkItemProperty.model_validate(response)
+
+    def retrieve(self, workspace_slug: str, property_id: str) -> WorkItemProperty:
+        """Retrieve a workspace work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+        """
+        response = self._get(f"{workspace_slug}/work-item-properties/{property_id}")
         return WorkItemProperty.model_validate(response)
 
     def delete(self, workspace_slug: str, property_id: str) -> None:
@@ -65,4 +75,4 @@ class WorkspaceWorkItemProperties(BaseResource):
             workspace_slug: The workspace slug identifier
             property_id: UUID of the work item property
         """
-        return self._delete(f"{workspace_slug}/work-item-properties/{property_id}/")
+        return self._delete(f"{workspace_slug}/work-item-properties/{property_id}")

--- a/plane/api/workspace_work_item_properties/options.py
+++ b/plane/api/workspace_work_item_properties/options.py
@@ -22,7 +22,7 @@ class WorkspaceWorkItemPropertyOptions(BaseResource):
             property_id: UUID of the work item property
         """
         response = self._get(
-            f"{workspace_slug}/work-item-properties/{property_id}/options/"
+            f"{workspace_slug}/work-item-properties/{property_id}/options"
         )
         return [WorkItemPropertyOption.model_validate(item) for item in response]
 
@@ -40,7 +40,7 @@ class WorkspaceWorkItemPropertyOptions(BaseResource):
             data: Option data
         """
         response = self._post(
-            f"{workspace_slug}/work-item-properties/{property_id}/options/",
+            f"{workspace_slug}/work-item-properties/{property_id}/options",
             data.model_dump(exclude_none=True),
         )
         return WorkItemPropertyOption.model_validate(response)
@@ -61,7 +61,34 @@ class WorkspaceWorkItemPropertyOptions(BaseResource):
             data: Updated option data
         """
         response = self._patch(
-            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}/",
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}",
             data.model_dump(exclude_none=True),
         )
         return WorkItemPropertyOption.model_validate(response)
+
+    def retrieve(
+        self, workspace_slug: str, property_id: str, option_id: str
+    ) -> WorkItemPropertyOption:
+        """Retrieve an option for a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            option_id: UUID of the option
+        """
+        response = self._get(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}"
+        )
+        return WorkItemPropertyOption.model_validate(response)
+
+    def delete(self, workspace_slug: str, property_id: str, option_id: str) -> None:
+        """Delete an option from a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            option_id: UUID of the option
+        """
+        return self._delete(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}"
+        )

--- a/plane/api/workspace_work_item_types/base.py
+++ b/plane/api/workspace_work_item_types/base.py
@@ -20,7 +20,7 @@ class WorkspaceWorkItemTypes(BaseResource):
         Args:
             workspace_slug: The workspace slug identifier
         """
-        response = self._get(f"{workspace_slug}/work-item-types/")
+        response = self._get(f"{workspace_slug}/work-item-types")
         return [WorkItemType.model_validate(item) for item in response]
 
     def create(self, workspace_slug: str, data: CreateWorkItemType) -> WorkItemType:
@@ -31,9 +31,19 @@ class WorkspaceWorkItemTypes(BaseResource):
             data: Work item type data
         """
         response = self._post(
-            f"{workspace_slug}/work-item-types/",
+            f"{workspace_slug}/work-item-types",
             data.model_dump(exclude_none=True),
         )
+        return WorkItemType.model_validate(response)
+
+    def retrieve(self, workspace_slug: str, type_id: str) -> WorkItemType:
+        """Retrieve a workspace work item type by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+        """
+        response = self._get(f"{workspace_slug}/work-item-types/{type_id}")
         return WorkItemType.model_validate(response)
 
     def update(
@@ -47,7 +57,16 @@ class WorkspaceWorkItemTypes(BaseResource):
             data: Updated work item type data
         """
         response = self._patch(
-            f"{workspace_slug}/work-item-types/{type_id}/",
+            f"{workspace_slug}/work-item-types/{type_id}",
             data.model_dump(exclude_none=True),
         )
         return WorkItemType.model_validate(response)
+
+    def delete(self, workspace_slug: str, type_id: str) -> None:
+        """Delete a workspace work item type by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+        """
+        return self._delete(f"{workspace_slug}/work-item-types/{type_id}")

--- a/plane/api/workspace_work_item_types/properties.py
+++ b/plane/api/workspace_work_item_types/properties.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ...models.work_item_properties import WorkItemProperty
+from ...models.work_item_properties import WorkItemProperty  # used for create/delete return types
 from ...models.work_item_types import WorkspaceWorkItemTypePropertyLink
 from ..base_resource import BaseResource
 
@@ -11,17 +11,21 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
     def __init__(self, config: Any) -> None:
         super().__init__(config, "/workspaces/")
 
-    def list(self, workspace_slug: str, type_id: str) -> list[WorkItemProperty]:
-        """List properties linked to a workspace work item type.
+    def list(self, workspace_slug: str, type_id: str) -> list[str]:
+        """List property UUIDs linked to a workspace work item type.
+
+        The API returns a flat list of UUID strings, not full property objects.
+        To get full WorkItemProperty objects, resolve these UUIDs via
+        workspace_work_item_properties.list() or .retrieve().
 
         Args:
             workspace_slug: The workspace slug identifier
             type_id: UUID of the work item type
         """
         response = self._get(
-            f"{workspace_slug}/work-item-types/{type_id}/properties/"
+            f"{workspace_slug}/work-item-types/{type_id}/properties"
         )
-        return [WorkItemProperty.model_validate(item) for item in response]
+        return list(response)
 
     def create(
         self, workspace_slug: str, type_id: str, data: WorkspaceWorkItemTypePropertyLink
@@ -34,7 +38,7 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
             data: DTO containing the property_id to link
         """
         response = self._post(
-            f"{workspace_slug}/work-item-types/{type_id}/properties/",
+            f"{workspace_slug}/work-item-types/{type_id}/properties",
             data.model_dump(exclude_none=True),
         )
         return WorkItemProperty.model_validate(response)
@@ -48,5 +52,5 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
             property_id: UUID of the property to unlink
         """
         return self._delete(
-            f"{workspace_slug}/work-item-types/{type_id}/properties/{property_id}/"
+            f"{workspace_slug}/work-item-types/{type_id}/properties/{property_id}"
         )

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -23,7 +23,7 @@ class WorkItem(BaseModel):
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description_html: str | None = None
     description_stripped: str | None = None
     description_binary: str | None = None
@@ -39,12 +39,12 @@ class WorkItem(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     state: str | StateLite | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class WorkItemDetail(BaseModel):
@@ -53,14 +53,14 @@ class WorkItemDetail(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     id: str | None = None
-    assignees: list[UserLite]
-    labels: list[Label]
+    assignees: list[UserLite] = Field(default_factory=list)
+    labels: list[Label] = Field(default_factory=list)
     type_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description_html: str | None = None
     description_stripped: str | None = None
     description_binary: str | None = None
@@ -76,12 +76,12 @@ class WorkItemDetail(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     state: str | StateLite | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class WorkItemExpand(BaseModel):
@@ -99,7 +99,7 @@ class WorkItemExpand(BaseModel):
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description: Any | None = None
     description_html: str | None = None
     description_stripped: str | None = None
@@ -116,11 +116,11 @@ class WorkItemExpand(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class CreateWorkItem(BaseModel):


### PR DESCRIPTION
 Description:

  ## Summary

  - Add project-level work item property CRUD (`list_project`, `create_project`, `retrieve_project`, `update_project`, `delete_project`) and type attachment helpers (`attach_to_type`, `detach_from_type`) 
  - Add `work_items.list_workspace()` for workspace-wide work item queries
  - Add missing `retrieve` and `delete` methods on workspace work item types, properties, and property options
  - Fix double-slash 404s: strip trailing slashes from all workspace-level endpoint strings (`_build_url` appends `/` automatically)
  - Fix `WorkspaceWorkItemTypeProperties.list()` to return `list[str]` (API returns flat UUID list, not property objects)
  - Relax `WorkItem` / `WorkItemDetail` / `WorkItemExpand` models: `name` optional, `project`/`type` accept `str | dict`, `assignees`/`labels` default to empty list
  
### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update