### PR TITLE
fix: normalize URL parts in _build_url to prevent malformed URLs

### DIFF
--- a/plane/api/base_resource.py
+++ b/plane/api/base_resource.py
@@ -68,8 +68,8 @@ class BaseResource:
 
     # Helpers
     def _build_url(self, endpoint: str) -> str:
-        endpoint = endpoint.lstrip("/")
-        base = f"{self.config.base_path}{self.base_path}/"
+        endpoint = endpoint.strip("/")
+        base = f"{self.config.base_path.rstrip('/')}{self.base_path}/"
         return f"{base}{endpoint}/" if endpoint else base
 
     def _headers(self) -> dict[str, str]:


### PR DESCRIPTION
### Description

Normalized `base_path` and `endpoint` strings in `_build_url()` to prevent malformed URLs caused by redundant or missing slashes.

This change:

* strips trailing `/` from `config.base_path`
* strips leading/trailing `/` from endpoints
* ensures consistent URL generation regardless of caller input

Example:

Before:

```python
config.base_path = "https://api.example.com/"
endpoint = "releases/"
```

Generated:

```text
https://api.example.com//workspaces/releases//
```

After:

```text
https://api.example.com/workspaces/releases/
```

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request URL construction and path normalization to ensure consistent handling of leading and trailing slashes in both endpoint configurations and base path settings. This enhancement reduces the risk of routing errors and ensures more reliable, consistently formatted request paths across all API interactions throughout the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane-python-sdk/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->