### PR TITLE
feat: project-level property APIs, workspace CRUD completions, and resilient work item models

### DIFF
--- a/plane/api/work_item_properties/base.py
+++ b/plane/api/work_item_properties/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any
 
@@ -90,6 +92,119 @@ class WorkItemProperties(BaseResource):
             f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/work-item-properties/{work_item_property_id}"
         )
 
+    def list_project(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> list[WorkItemProperty]:
+        """List all work item properties for a project regardless of work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            params: Optional query parameters
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties",
+            params=params,
+        )
+        return [WorkItemProperty.model_validate(item) for item in response]
+
+    def create_project(
+        self, workspace_slug: str, project_id: str, data: CreateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Create a project-level work item property (not linked to a specific type).
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            data: Work item property data
+        """
+        response = self._post(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def retrieve_project(
+        self, workspace_slug: str, project_id: str, property_id: str
+    ) -> WorkItemProperty:
+        """Retrieve a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}"
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def update_project(
+        self, workspace_slug: str, project_id: str, property_id: str, data: UpdateWorkItemProperty
+    ) -> WorkItemProperty:
+        """Update a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+            data: Updated property data
+        """
+        response = self._patch(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}",
+            data.model_dump(exclude_none=True),
+        )
+        return WorkItemProperty.model_validate(response)
+
+    def delete_project(
+        self, workspace_slug: str, project_id: str, property_id: str
+    ) -> None:
+        """Delete a project-level work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            property_id: UUID of the property
+        """
+        return self._delete(
+            f"{workspace_slug}/projects/{project_id}/work-item-properties/{property_id}"
+        )
+
+    def attach_to_type(
+        self, workspace_slug: str, project_id: str, type_id: str, property_ids: list[str]
+    ) -> list[str]:
+        """Attach existing project-level properties to a work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            type_id: UUID of the work item type
+            property_ids: List of property UUIDs to attach
+        """
+        response = self._post(
+            f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/properties",
+            {"properties": property_ids},
+        )
+        return response.get("properties", [])
+
+    def detach_from_type(
+        self, workspace_slug: str, project_id: str, type_id: str, property_id: str
+    ) -> None:
+        """Detach a property from a work item type.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            type_id: UUID of the work item type
+            property_id: UUID of the property to detach
+        """
+        return self._delete(
+            f"{workspace_slug}/projects/{project_id}/work-item-types/{type_id}/properties/{property_id}"
+        )
+
     def list(
         self,
         workspace_slug: str,
@@ -97,7 +212,7 @@ class WorkItemProperties(BaseResource):
         type_id: str,
         params: Mapping[str, Any] | None = None,
     ) -> list[WorkItemProperty]:
-        """List work item properties with optional filtering parameters.
+        """List project-level work item properties for a type.
 
         Args:
             workspace_slug: The workspace slug identifier
@@ -110,3 +225,4 @@ class WorkItemProperties(BaseResource):
             params=params,
         )
         return [WorkItemProperty.model_validate(item) for item in response]
+

--- a/plane/api/work_items/base.py
+++ b/plane/api/work_items/base.py
@@ -177,6 +177,23 @@ class WorkItems(BaseResource):
         )
         return PaginatedWorkItemResponse.model_validate(response)
 
+    def list_workspace(
+        self,
+        workspace_slug: str,
+        params: WorkItemQueryParams | None = None,
+    ) -> PaginatedWorkItemResponse:
+        """List work items across the entire workspace.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            params: Optional query parameters for filtering, ordering, and pagination
+        """
+        query_params = params.model_dump(exclude_none=True) if params else None
+        response = self._get(
+            f"{workspace_slug}/work-items", params=query_params
+        )
+        return PaginatedWorkItemResponse.model_validate(response)
+
     def search(
         self,
         workspace_slug: str,

--- a/plane/api/workspace_work_item_properties/base.py
+++ b/plane/api/workspace_work_item_properties/base.py
@@ -58,6 +58,16 @@ class WorkspaceWorkItemProperties(BaseResource):
         )
         return WorkItemProperty.model_validate(response)
 
+    def retrieve(self, workspace_slug: str, property_id: str) -> WorkItemProperty:
+        """Retrieve a workspace work item property by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+        """
+        response = self._get(f"{workspace_slug}/work-item-properties/{property_id}/")
+        return WorkItemProperty.model_validate(response)
+
     def delete(self, workspace_slug: str, property_id: str) -> None:
         """Delete a work item property in the workspace.
 

--- a/plane/api/workspace_work_item_properties/options.py
+++ b/plane/api/workspace_work_item_properties/options.py
@@ -65,3 +65,30 @@ class WorkspaceWorkItemPropertyOptions(BaseResource):
             data.model_dump(exclude_none=True),
         )
         return WorkItemPropertyOption.model_validate(response)
+
+    def retrieve(
+        self, workspace_slug: str, property_id: str, option_id: str
+    ) -> WorkItemPropertyOption:
+        """Retrieve an option for a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            option_id: UUID of the option
+        """
+        response = self._get(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}/"
+        )
+        return WorkItemPropertyOption.model_validate(response)
+
+    def delete(self, workspace_slug: str, property_id: str, option_id: str) -> None:
+        """Delete an option from a workspace work item property.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            property_id: UUID of the work item property
+            option_id: UUID of the option
+        """
+        return self._delete(
+            f"{workspace_slug}/work-item-properties/{property_id}/options/{option_id}/"
+        )

--- a/plane/api/workspace_work_item_types/base.py
+++ b/plane/api/workspace_work_item_types/base.py
@@ -36,6 +36,16 @@ class WorkspaceWorkItemTypes(BaseResource):
         )
         return WorkItemType.model_validate(response)
 
+    def retrieve(self, workspace_slug: str, type_id: str) -> WorkItemType:
+        """Retrieve a workspace work item type by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+        """
+        response = self._get(f"{workspace_slug}/work-item-types/{type_id}/")
+        return WorkItemType.model_validate(response)
+
     def update(
         self, workspace_slug: str, type_id: str, data: UpdateWorkItemType
     ) -> WorkItemType:
@@ -51,3 +61,12 @@ class WorkspaceWorkItemTypes(BaseResource):
             data.model_dump(exclude_none=True),
         )
         return WorkItemType.model_validate(response)
+
+    def delete(self, workspace_slug: str, type_id: str) -> None:
+        """Delete a workspace work item type by ID.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            type_id: UUID of the work item type
+        """
+        return self._delete(f"{workspace_slug}/work-item-types/{type_id}/")

--- a/plane/api/workspace_work_item_types/properties.py
+++ b/plane/api/workspace_work_item_types/properties.py
@@ -11,8 +11,12 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
     def __init__(self, config: Any) -> None:
         super().__init__(config, "/workspaces/")
 
-    def list(self, workspace_slug: str, type_id: str) -> list[WorkItemProperty]:
-        """List properties linked to a workspace work item type.
+    def list(self, workspace_slug: str, type_id: str) -> list[str]:
+        """List property UUIDs linked to a workspace work item type.
+
+        The API returns a flat list of UUID strings, not full property objects.
+        To get full WorkItemProperty objects, resolve these UUIDs via
+        workspace_work_item_properties.list() or .retrieve().
 
         Args:
             workspace_slug: The workspace slug identifier
@@ -21,7 +25,7 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
         response = self._get(
             f"{workspace_slug}/work-item-types/{type_id}/properties/"
         )
-        return [WorkItemProperty.model_validate(item) for item in response]
+        return list(response)
 
     def create(
         self, workspace_slug: str, type_id: str, data: WorkspaceWorkItemTypePropertyLink

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -23,7 +23,7 @@ class WorkItem(BaseModel):
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description_html: str | None = None
     description_stripped: str | None = None
     description_binary: str | None = None
@@ -39,12 +39,12 @@ class WorkItem(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     state: str | StateLite | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class WorkItemDetail(BaseModel):
@@ -53,14 +53,14 @@ class WorkItemDetail(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     id: str | None = None
-    assignees: list[UserLite]
-    labels: list[Label]
+    assignees: list[UserLite] = Field(default_factory=list)
+    labels: list[Label] = Field(default_factory=list)
     type_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description_html: str | None = None
     description_stripped: str | None = None
     description_binary: str | None = None
@@ -76,12 +76,12 @@ class WorkItemDetail(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     state: str | StateLite | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class WorkItemExpand(BaseModel):
@@ -99,7 +99,7 @@ class WorkItemExpand(BaseModel):
     updated_at: str | None = None
     deleted_at: str | None = None
     point: int | None = None
-    name: str
+    name: str | None = None
     description: Any | None = None
     description_html: str | None = None
     description_stripped: str | None = None
@@ -116,11 +116,11 @@ class WorkItemExpand(BaseModel):
     external_id: str | None = None
     created_by: str | None = None
     updated_by: str | None = None
-    project: str | None = None
+    project: str | dict | None = None
     workspace: str | None = None
     parent: str | None = None
     estimate_point: str | None = None
-    type: str | None = None
+    type: str | dict | None = None
 
 
 class CreateWorkItem(BaseModel):

--- a/tests/unit/test_work_item_properties.py
+++ b/tests/unit/test_work_item_properties.py
@@ -644,3 +644,127 @@ class TestWorkItemPropertyTypes:
             )
         except Exception:
             pass
+
+
+class TestProjectLevelWorkItemPropertiesAPI:
+    """Test project-level (type-agnostic) work item property endpoints."""
+
+    def test_list_project_work_item_properties(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+    ) -> None:
+        """Test listing all work item properties for a project regardless of type."""
+        properties = client.work_item_properties.list_project(workspace_slug, project.id)
+        assert isinstance(properties, list)
+
+    def test_create_retrieve_update_delete_project_property(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+    ) -> None:
+        """Test full CRUD for a project-level work item property."""
+        import time
+
+        from plane.errors.errors import HttpError
+        from plane.models.work_item_property_configurations import TextAttributeSettings
+
+        display_name = f"Project Prop {int(time.time())}"
+        data = CreateWorkItemProperty(
+            display_name=display_name,
+            description="Project-level property",
+            property_type=PropertyType.TEXT,
+            is_required=False,
+            is_active=True,
+            settings=TextAttributeSettings(display_format="multi-line"),
+        )
+        try:
+            created = client.work_item_properties.create_project(workspace_slug, project.id, data)
+        except HttpError as e:
+            if e.status_code == 400:
+                pytest.skip(
+                    "Workspace has IS_WORK_ITEM_TYPES_ENABLED — project-level property creation blocked"
+                )
+            raise
+        assert created is not None
+        assert created.id is not None
+        assert created.display_name == display_name
+
+        try:
+            retrieved = client.work_item_properties.retrieve_project(
+                workspace_slug, project.id, created.id
+            )
+            assert retrieved.id == created.id
+            assert retrieved.display_name == display_name
+
+            updated = client.work_item_properties.update_project(
+                workspace_slug,
+                project.id,
+                created.id,
+                UpdateWorkItemProperty(description="Updated project property"),
+            )
+            assert updated.id == created.id
+            assert updated.description == "Updated project property"
+        finally:
+            try:
+                client.work_item_properties.delete_project(
+                    workspace_slug, project.id, created.id
+                )
+            except Exception:
+                pass
+
+    def test_attach_detach_property_to_type(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+    ) -> None:
+        """Test attaching and detaching a project-level property to/from a work item type."""
+        import time
+
+        from plane.models.work_item_property_configurations import TextAttributeSettings
+        from plane.models.work_item_types import CreateWorkItemType
+
+        from plane.errors.errors import HttpError
+
+        type_data = CreateWorkItemType(
+            name=f"Attach Test Type {int(time.time())}",
+            is_active=True,
+        )
+        try:
+            wit = client.work_item_types.create(workspace_slug, project.id, type_data)
+        except HttpError as e:
+            if e.status_code == 400:
+                pytest.skip(
+                    "Workspace has IS_WORK_ITEM_TYPES_ENABLED — project-level type creation blocked"
+                )
+            raise
+
+        prop_data = CreateWorkItemProperty(
+            display_name=f"Attach Test Prop {int(time.time())}",
+            property_type=PropertyType.TEXT,
+            is_active=True,
+            settings=TextAttributeSettings(display_format="multi-line"),
+        )
+        prop = client.work_item_properties.create_project(workspace_slug, project.id, prop_data)
+
+        try:
+            result = client.work_item_properties.attach_to_type(
+                workspace_slug, project.id, wit.id, [prop.id]
+            )
+            assert isinstance(result, list)
+
+            client.work_item_properties.detach_from_type(
+                workspace_slug, project.id, wit.id, prop.id
+            )
+        finally:
+            try:
+                client.work_item_properties.delete_project(workspace_slug, project.id, prop.id)
+            except Exception:
+                pass
+            try:
+                client.work_item_types.delete(workspace_slug, project.id, wit.id)
+            except Exception:
+                pass

--- a/tests/unit/test_work_item_properties.py
+++ b/tests/unit/test_work_item_properties.py
@@ -748,7 +748,15 @@ class TestProjectLevelWorkItemPropertiesAPI:
             is_active=True,
             settings=TextAttributeSettings(display_format="multi-line"),
         )
-        prop = client.work_item_properties.create_project(workspace_slug, project.id, prop_data)
+        try:
+            prop = client.work_item_properties.create_project(workspace_slug, project.id, prop_data)
+        except HttpError as e:
+            if e.status_code == 400:
+                client.work_item_types.delete(workspace_slug, project.id, wit.id)
+                pytest.skip(
+                    "Workspace has IS_WORK_ITEM_TYPES_ENABLED — project-level property creation blocked"
+                )
+            raise
 
         try:
             result = client.work_item_properties.attach_to_type(

--- a/tests/unit/test_work_items.py
+++ b/tests/unit/test_work_items.py
@@ -78,6 +78,27 @@ class TestWorkItemsAPI:
             if created_item_2 is not None:
                 client.work_items.delete(workspace_slug, project.id, created_item_2.id)
 
+    def test_list_workspace_work_items(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test listing work items across the entire workspace (no project_id)."""
+        response = client.work_items.list_workspace(workspace_slug)
+        assert response is not None
+        assert hasattr(response, "results")
+        assert hasattr(response, "count")
+        assert isinstance(response.results, list)
+
+    def test_list_workspace_work_items_with_pagination(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test workspace work item listing respects per_page param."""
+        from plane.models.query_params import WorkItemQueryParams
+
+        params = WorkItemQueryParams(per_page=5)
+        response = client.work_items.list_workspace(workspace_slug, params=params)
+        assert response is not None
+        assert len(response.results) <= 5
+
     def test_search_work_items(self, client: PlaneClient, workspace_slug: str) -> None:
         """Test searching work items."""
         response = client.work_items.search(workspace_slug, "test")

--- a/tests/unit/test_workspace_work_item_properties.py
+++ b/tests/unit/test_workspace_work_item_properties.py
@@ -26,6 +26,19 @@ class TestWorkspaceWorkItemProperties:
         props = client.workspace_work_item_properties.list(workspace_slug)
         assert isinstance(props, list)
 
+    def test_retrieve_workspace_work_item_property(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test retrieving a single workspace work item property by ID."""
+        props = client.workspace_work_item_properties.list(workspace_slug)
+        if not props:
+            pytest.skip("No workspace properties available to test retrieve")
+
+        prop = props[0]
+        retrieved = client.workspace_work_item_properties.retrieve(workspace_slug, prop.id)
+        assert retrieved is not None
+        assert retrieved.id == prop.id
+
     def test_create_update_delete_workspace_property(
         self, client: PlaneClient, workspace_slug: str
     ) -> None:
@@ -111,6 +124,51 @@ class TestWorkspaceWorkItemPropertyOptions:
             )
             assert updated_opt.id == opt.id
             assert updated_opt.name == f"{option_name}-updated"
+        finally:
+            try:
+                client.workspace_work_item_properties.delete(workspace_slug, prop.id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Teardown failed for workspace property {prop.id}: {exc}",
+                    stacklevel=1,
+                )
+
+    def test_retrieve_and_delete_option_for_workspace_property(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test retrieve and delete on a workspace property option."""
+        display_name = f"test-del-opt-prop-{uuid4().hex[:8]}"
+        prop_data = CreateWorkItemProperty(
+            display_name=display_name,
+            description="Test option property for retrieve/delete",
+            property_type=PropertyType.OPTION,
+            is_active=True,
+        )
+        prop = client.workspace_work_item_properties.create(workspace_slug, prop_data)
+        assert prop is not None
+
+        try:
+            opt = client.workspace_work_item_properties.options.create(
+                workspace_slug,
+                prop.id,
+                CreateWorkItemPropertyOption(name=f"opt-{uuid4().hex[:6]}"),
+            )
+            assert opt is not None
+            assert opt.id is not None
+
+            retrieved = client.workspace_work_item_properties.options.retrieve(
+                workspace_slug, prop.id, opt.id
+            )
+            assert retrieved.id == opt.id
+            assert retrieved.name == opt.name
+
+            client.workspace_work_item_properties.options.delete(
+                workspace_slug, prop.id, opt.id
+            )
+            remaining = client.workspace_work_item_properties.options.list(
+                workspace_slug, prop.id
+            )
+            assert all(o.id != opt.id for o in remaining)
         finally:
             try:
                 client.workspace_work_item_properties.delete(workspace_slug, prop.id)

--- a/tests/unit/test_workspace_work_item_types.py
+++ b/tests/unit/test_workspace_work_item_types.py
@@ -40,7 +40,39 @@ class TestWorkspaceWorkItemTypes:
         )
         assert updated.id == created.id
         assert updated.description == "Updated description"
-        # No delete endpoint on workspace WITs per spec.
+
+        try:
+            client.workspace_work_item_types.delete(workspace_slug, created.id)
+        except Exception:
+            pass
+
+    def test_retrieve_workspace_work_item_type(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test retrieving a workspace work item type by ID."""
+        types = client.workspace_work_item_types.list(workspace_slug)
+        if not types:
+            pytest.skip("No workspace work item types available to test retrieve")
+
+        wit = types[0]
+        retrieved = client.workspace_work_item_types.retrieve(workspace_slug, wit.id)
+        assert retrieved is not None
+        assert retrieved.id == wit.id
+        assert retrieved.name == wit.name
+
+    def test_delete_workspace_work_item_type(
+        self, client: PlaneClient, workspace_slug: str
+    ) -> None:
+        """Test deleting a workspace work item type."""
+        name = f"test-del-wit-{uuid4().hex[:8]}"
+        data = CreateWorkItemType(name=name, description="To be deleted", is_active=True)
+        created = client.workspace_work_item_types.create(workspace_slug, data)
+        assert created is not None
+        assert created.id is not None
+
+        client.workspace_work_item_types.delete(workspace_slug, created.id)
+        types_after = client.workspace_work_item_types.list(workspace_slug)
+        assert all(t.id != created.id for t in types_after)
 
 
 class TestWorkspaceWorkItemTypeProperties:
@@ -84,7 +116,7 @@ class TestWorkspaceWorkItemTypeProperties:
         assert linked is not None
 
         current = client.workspace_work_item_types.properties.list(workspace_slug, wit.id)
-        linked_ids = [p.id for p in current]
-        assert prop.id in linked_ids
+        # API returns flat list of UUID strings
+        assert prop.id in list(current)
 
         client.workspace_work_item_types.properties.delete(workspace_slug, wit.id, prop.id)


### PR DESCRIPTION
## Summary

  - Add project-level work item property CRUD (`list_project`, `create_project`, `retrieve_project`, `update_project`, `delete_project`) and type-attachment helpers (`attach_to_type`,
  `detach_from_type`) on `work_item_properties`
  - Add `work_items.list_workspace()` for cross-project work item queries
  - Add missing `retrieve` and `delete` on `workspace_work_item_types`
  - Add missing `retrieve` and `delete` on `workspace_work_item_properties.options`
  - Add missing `retrieve` on `workspace_work_item_properties`
  - Fix `WorkspaceWorkItemTypeProperties.list()` return type: API returns flat `["uuid", ...]` — changed from `list[WorkItemProperty]` to `list[str]`
  - Relax `WorkItem` / `WorkItemDetail` / `WorkItemExpand` models:
    - `name`: `str` → `str | None` (API omits it in some list responses)
    - `project`, `type`: `str | None` → `str | dict | None` (expanded responses return nested objects)
    - `assignees`, `labels`: bare `list[T]` → `Field(default_factory=list)` (missing keys no longer raise `ValidationError`)

  ## Test plan

  - [ ] `work_item_properties.list_project()` returns all properties for a project
  - [ ] `work_item_properties.attach_to_type()` / `detach_from_type()` link and unlink properties
  - [ ] `work_items.list_workspace()` paginates across all projects
  - [ ] `workspace_work_item_types.retrieve()` / `delete()` return correct types, no 404
  - [ ] `workspace_work_item_properties.retrieve()` resolves a known UUID
  - [ ] `workspace_work_item_properties.options.retrieve()` / `delete()` work correctly
  - [ ] `workspace_work_item_types.properties.list()` returns `list[str]`, not `list[WorkItemProperty]`
  - [ ] `WorkItem.model_validate(...)` succeeds when `name` is absent or `project` is an expanded dict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manage work item properties at the project level with full create, read, update, and delete capabilities.
  * Attach and detach work item properties to types for better organization.
  * List work items across your entire workspace in a single view.
  * Retrieve and delete workspace-level work item properties and types.
  * Enhanced work item data model for greater flexibility in property relationships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane-python-sdk/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->