### PR TITLE
fix: correct workspace type property linking API contract

### DIFF
--- a/plane/api/workspace_work_item_types/properties.py
+++ b/plane/api/workspace_work_item_types/properties.py
@@ -29,19 +29,17 @@ class WorkspaceWorkItemTypeProperties(BaseResource):
 
     def create(
         self, workspace_slug: str, type_id: str, data: WorkspaceWorkItemTypePropertyLink
-    ) -> WorkItemProperty:
-        """Link a property to a workspace work item type.
-
+    ) -> None:
+        """Link one or more properties to a workspace work item type.
         Args:
             workspace_slug: The workspace slug identifier
             type_id: UUID of the work item type
-            data: DTO containing the property_id to link
+            data: DTO containing properties (list of UUIDs) to link
         """
-        response = self._post(
+        self._post(
             f"{workspace_slug}/work-item-types/{type_id}/properties/",
             data.model_dump(exclude_none=True),
         )
-        return WorkItemProperty.model_validate(response)
 
     def delete(self, workspace_slug: str, type_id: str, property_id: str) -> None:
         """Unlink a property from a workspace work item type.

--- a/plane/models/work_item_types.py
+++ b/plane/models/work_item_types.py
@@ -58,8 +58,8 @@ class UpdateWorkItemType(BaseModel):
 
 
 class WorkspaceWorkItemTypePropertyLink(BaseModel):
-    """Request model for linking a property to a workspace work item type."""
+    """Request model for linking properties to a workspace work item type."""
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    property_id: str
+    properties: list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plane-sdk"
-version = "0.2.13"
+version = "0.2.14"
 description = "Python SDK for Plane API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Description:
  ### Description
  The workspace work item type properties endpoint (`POST /workspaces/{slug}/work-item-types/{type_id}/properties/`) expects a `properties` array, not a single `property_id`. The endpoint also returns HTTP 201 with no response body.
 
  Changes:
  - `WorkspaceWorkItemTypePropertyLink`: `property_id: str` → `properties: list[str]` to match API contract
  - `WorkspaceWorkItemTypeProperties.create()`: removed response parsing (`model_validate`) since API returns empty 201

  ### Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ### Test Scenarios
  - Link a single property to a workspace work item type → returns 201, no error
  - Link multiple properties in one call → accepted by API