### PR TITLE
fix: accept unexpanded id lists for WorkItemDetail assignees/labels

### DIFF
--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -53,8 +53,11 @@ class WorkItemDetail(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     id: str | None = None
-    assignees: list[UserLite] = Field(default_factory=list)
-    labels: list[Label] = Field(default_factory=list)
+    # The API returns bare UUID strings for these relations unless the request
+    # expands them (``expand=assignees,labels``), so accept both shapes — the
+    # same tolerance ``state`` (``str | StateLite``) and ``WorkItemExpand`` use.
+    assignees: list[str] | list[UserLite] = Field(default_factory=list)
+    labels: list[str] | list[Label] = Field(default_factory=list)
     type_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None

--- a/tests/unit/test_work_item_models.py
+++ b/tests/unit/test_work_item_models.py
@@ -1,0 +1,48 @@
+"""Pure model-validation tests for work item response models (no HTTP).
+
+The Plane API returns ``assignees`` and ``labels`` on a work item as bare UUID
+strings unless the request expands them (``expand=assignees,labels``), in which
+case they come back as nested objects. ``WorkItemDetail`` must accept both
+shapes — the same tolerance it already grants ``state`` (``str | StateLite``).
+"""
+
+from plane.models.labels import Label
+from plane.models.users import UserLite
+from plane.models.work_items import WorkItemDetail
+
+
+class TestWorkItemDetailRelations:
+    def test_accepts_unexpanded_id_lists(self) -> None:
+        """Default (unexpanded) responses carry bare UUID strings."""
+        item = WorkItemDetail.model_validate(
+            {
+                "id": "wi-1",
+                "assignees": ["00000000-0000-0000-0000-000000000001"],
+                "labels": ["00000000-0000-0000-0000-000000000002"],
+                "state": "00000000-0000-0000-0000-000000000003",
+            }
+        )
+        assert item.assignees == ["00000000-0000-0000-0000-000000000001"]
+        assert item.labels == ["00000000-0000-0000-0000-000000000002"]
+        assert item.state == "00000000-0000-0000-0000-000000000003"
+
+    def test_accepts_expanded_object_lists(self) -> None:
+        """``expand=assignees,labels`` responses carry nested objects."""
+        item = WorkItemDetail.model_validate(
+            {
+                "id": "wi-1",
+                "assignees": [{"id": "u-1", "display_name": "henry"}],
+                "labels": [{"id": "l-1", "name": "bug"}],
+                "state": {"id": "s-1", "name": "Todo"},
+            }
+        )
+        assert isinstance(item.assignees[0], UserLite)
+        assert item.assignees[0].id == "u-1"
+        assert isinstance(item.labels[0], Label)
+        assert item.labels[0].name == "bug"
+
+    def test_defaults_to_empty_lists(self) -> None:
+        """Absent relations default to empty lists, not None."""
+        item = WorkItemDetail.model_validate({"id": "wi-1"})
+        assert item.assignees == []
+        assert item.labels == []


### PR DESCRIPTION
## Problem

`WorkItemDetail` types its relations strictly:

```python
assignees: list[UserLite] = Field(default_factory=list)
labels: list[Label] = Field(default_factory=list)
```

But the Plane API returns `assignees` and `labels` as **bare UUID strings** unless the request explicitly expands them (`expand=assignees,labels`). So retrieving any *assigned or labelled* work item without that expand raises:

```
pydantic_core.ValidationError: 2 validation errors for WorkItemDetail
assignees.0  Input should be a valid dictionary or instance of UserLite
             [input_value='00000000-...', input_type=str]
labels.0     Input should be a valid dictionary or instance of Label
             [input_value='00000000-...', input_type=str]
```

This makes a plain `work_items.retrieve(...)` (no `expand`) fail on real data — e.g. it surfaces through `plane-mcp-server`'s `retrieve_work_item_*` tools against a self-hosted (CE) instance, where the default serializer returns the unexpanded shape.

## Fix

Widen both relations to accept either shape:

```python
assignees: list[str] | list[UserLite] = Field(default_factory=list)
labels: list[str] | list[Label] = Field(default_factory=list)
```

This mirrors the tolerance the same model already grants `state` (`str | StateLite`) and that the sibling `WorkItemExpand` model already uses for `assignees`/`labels`. No behavior change for callers who *do* expand — those still validate into `UserLite`/`Label` objects.

## Tests

Adds `tests/unit/test_work_item_models.py` — pure model-validation tests (no HTTP) covering the unexpanded (bare-ID), expanded (nested-object), and default-empty shapes. The unexpanded case fails on `main` and passes with this change; the full unit suite stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced work item models to flexibly accept both compact (ID-only) and expanded (full object) representations of related data in API responses.

* **Tests**
  * Added test coverage validating model behavior with both expanded and unexpanded data formats, plus default empty list handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->