### PR TITLE
feat: add group_by/sub_group_by support to list_workspace work items

### DIFF
--- a/plane/api/work_items/base.py
+++ b/plane/api/work_items/base.py
@@ -4,12 +4,14 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
-from ...models.query_params import RetrieveQueryParams, WorkItemQueryParams
+from ...models.query_params import RetrieveQueryParams, WorkItemQueryParams, WorkspaceWorkItemQueryParams
 from ...models.work_items import (
     AdvancedSearchResult,
     AdvancedSearchWorkItem,
     CreateWorkItem,
+    GroupedPaginatedWorkItemResponse,
     PaginatedWorkItemResponse,
+    SubGroupedPaginatedWorkItemResponse,
     UpdateWorkItem,
     WorkItem,
     WorkItemDetail,
@@ -213,53 +215,81 @@ class WorkItems(BaseResource):
     def list_workspace(
         self,
         workspace_slug: str,
-        params: WorkItemQueryParams | None = None,
-    ) -> PaginatedWorkItemResponse:
+        params: WorkspaceWorkItemQueryParams | None = None,
+    ) -> PaginatedWorkItemResponse | GroupedPaginatedWorkItemResponse | SubGroupedPaginatedWorkItemResponse:
         """List work items across an entire workspace.
 
         Returns a paginated envelope of work items the caller can view,
         spanning every project in the workspace (per-project authorization
         and conditional grants are honored server-side).
 
+        The return type depends on the ``group_by`` / ``sub_group_by`` params:
+
+        - Neither set → :class:`~plane.models.work_items.PaginatedWorkItemResponse`
+          (``results`` is a flat list of work items)
+        - ``group_by`` only → :class:`~plane.models.work_items.GroupedPaginatedWorkItemResponse`
+          (``results`` is ``dict[group_value, WorkItemGroupBucket]``)
+        - Both set → :class:`~plane.models.work_items.SubGroupedPaginatedWorkItemResponse`
+          (``results`` is ``dict[group_value, dict[sub_group_value, WorkItemGroupBucket]]``)
+
+        ``group_by`` and ``sub_group_by`` must differ; the server returns
+        HTTP 400 when they are the same.
+
         Args:
             workspace_slug: The workspace slug identifier
             params: Optional query parameters — supports ``filters``, ``pql``,
-                ``order_by``, ``cursor``, ``per_page``, ``fields``, ``expand``.
+                ``order_by``, ``cursor``, ``per_page``, ``fields``, ``expand``,
+                ``group_by``, ``sub_group_by``, ``sub_issue``.
 
-        Example::
+        Example — flat list::
 
-            from plane.models.query_params import WorkItemQueryParams
+            from plane.models.query_params import WorkspaceWorkItemQueryParams
 
             results = client.work_items.list_workspace(
                 "my-workspace",
-                params=WorkItemQueryParams(
+                params=WorkspaceWorkItemQueryParams(
                     filters={"priority": "urgent"},
                     order_by="-created_at",
                     per_page=50,
                 ),
             )
+
+        Example — grouped by state::
+
+            from plane.models.query_params import WorkspaceWorkItemQueryParams
+
+            response = client.work_items.list_workspace(
+                "my-workspace",
+                params=WorkspaceWorkItemQueryParams(group_by="state_id"),
+            )
+            for state_id, bucket in response.results.items():
+                print(state_id, bucket.total_results, bucket.results)
+
+        Example — sub-grouped by priority within each state::
+
+            from plane.models.query_params import WorkspaceWorkItemQueryParams
+
+            response = client.work_items.list_workspace(
+                "my-workspace",
+                params=WorkspaceWorkItemQueryParams(
+                    group_by="state_id",
+                    sub_group_by="priority",
+                ),
+            )
+            for state_id, sub_groups in response.results.items():
+                for priority, bucket in sub_groups.items():
+                    print(state_id, priority, bucket.total_results)
         """
         response = self._get(
             f"{workspace_slug}/work-items",
             params=prepare_work_item_params(params),
         )
-        return PaginatedWorkItemResponse.model_validate(response)
-
-    def list_workspace(
-        self,
-        workspace_slug: str,
-        params: WorkItemQueryParams | None = None,
-    ) -> PaginatedWorkItemResponse:
-        """List work items across the entire workspace.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            params: Optional query parameters for filtering, ordering, and pagination
-        """
-        query_params = params.model_dump(exclude_none=True) if params else None
-        response = self._get(
-            f"{workspace_slug}/work-items", params=query_params
-        )
+        grouped_by = response.get("grouped_by")
+        sub_grouped_by = response.get("sub_grouped_by")
+        if grouped_by and sub_grouped_by:
+            return SubGroupedPaginatedWorkItemResponse.model_validate(response)
+        if grouped_by:
+            return GroupedPaginatedWorkItemResponse.model_validate(response)
         return PaginatedWorkItemResponse.model_validate(response)
 
     def search(

--- a/plane/models/__init__.py
+++ b/plane/models/__init__.py
@@ -18,6 +18,7 @@ from .query_params import (
     PaginatedQueryParams,
     RetrieveQueryParams,
     WorkItemQueryParams,
+    WorkspaceWorkItemQueryParams,
 )
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     "PaginatedQueryParams",
     "RetrieveQueryParams",
     "WorkItemQueryParams",
+    "WorkspaceWorkItemQueryParams",
 ]
 
 

--- a/plane/models/query_params.py
+++ b/plane/models/query_params.py
@@ -84,6 +84,70 @@ class WorkItemQueryParams(PaginatedQueryParams):
     )
 
 
+#: Valid field names accepted by ``group_by`` and ``sub_group_by``.
+GROUP_BY_FIELDS = (
+    "state_id",
+    "priority",
+    "assignees__id",
+    "labels__id",
+    "cycle_id",
+    "issue_module__module_id",
+    "type_id",
+    "project_id",
+    "state__group",
+    "release_work_items__release_id",
+    "milestone_id",
+    "target_date",
+    "start_date",
+    "created_by",
+)
+
+
+class WorkspaceWorkItemQueryParams(WorkItemQueryParams):
+    """Query parameters for the workspace-scoped work item list endpoint.
+
+    Extends :class:`WorkItemQueryParams` with grouping and sub-issue controls
+    that are specific to ``GET /workspaces/{slug}/work-items``.
+
+    Grouping fields (``group_by``, ``sub_group_by``) change the shape of the
+    ``results`` envelope:
+
+    - Neither set → ``results`` is ``list[WorkItem]``
+    - ``group_by`` only → ``results`` is ``dict[str, WorkItemGroupBucket]``
+    - Both set → ``results`` is ``dict[str, dict[str, WorkItemGroupBucket]]``
+
+    ``group_by`` and ``sub_group_by`` must differ; the server returns HTTP 400
+    if they are the same.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    group_by: str | None = Field(
+        None,
+        description=(
+            "Field to group results by. When set the paginator returns a dict of "
+            "group buckets instead of a flat list. Valid values: "
+            + ", ".join(f"``{f}``" for f in GROUP_BY_FIELDS)
+        ),
+    )
+    sub_group_by: str | None = Field(
+        None,
+        description=(
+            "Field to nest a second grouping within each top-level group. "
+            "Requires ``group_by`` to be set and must differ from it. "
+            "Same valid values as ``group_by``."
+        ),
+    )
+    sub_issue: bool | None = Field(
+        None,
+        description=(
+            "When ``False``, only top-level items and direct children of epics "
+            "are returned (sub-issues are excluded). Omit or pass ``True`` to "
+            "include all items regardless of parent."
+        ),
+    )
+
+
 class RetrieveQueryParams(BaseQueryParams):
     """Query parameters for retrieve endpoints."""
 
@@ -95,4 +159,5 @@ __all__ = [
     "PaginatedQueryParams",
     "RetrieveQueryParams",
     "WorkItemQueryParams",
+    "WorkspaceWorkItemQueryParams",
 ]

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -564,12 +564,60 @@ class UpdateWorkItemWorkLog(BaseModel):
     updated_by: str | None = None
 
 
-class PaginatedWorkItemResponse(PaginatedResponse):
-    """Paginated response for work items."""
+class WorkItemGroupBucket(BaseModel):
+    """One bucket in a grouped or sub-grouped work item response.
+
+    Each key in the ``results`` dict of a grouped response maps to one of
+    these buckets.  For sub-grouped responses the value is itself a
+    ``dict[str, WorkItemGroupBucket]``.
+    """
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     results: list[WorkItem]
+    total_results: int
+
+
+class PaginatedWorkItemResponse(PaginatedResponse):
+    """Paginated response for work items (flat, no grouping)."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: list[WorkItem]
+
+
+class GroupedPaginatedWorkItemResponse(PaginatedResponse):
+    """Paginated response when ``group_by`` is set (no ``sub_group_by``).
+
+    ``results`` is a mapping from group-field value (stringified) to a
+    :class:`WorkItemGroupBucket` containing the items and per-group count.
+
+    Example::
+
+        response.results["<state-uuid>"].results   # list of WorkItem
+        response.results["<state-uuid>"].total_results  # int
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: dict[str, WorkItemGroupBucket]
+
+
+class SubGroupedPaginatedWorkItemResponse(PaginatedResponse):
+    """Paginated response when both ``group_by`` and ``sub_group_by`` are set.
+
+    ``results`` is a two-level mapping:
+    ``group-value → sub-group-value → WorkItemGroupBucket``.
+
+    Example::
+
+        response.results["<state-uuid>"]["urgent"].results       # list of WorkItem
+        response.results["<state-uuid>"]["urgent"].total_results # int
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: dict[str, dict[str, WorkItemGroupBucket]]
 
 
 class PaginatedWorkItemActivityResponse(PaginatedResponse):


### PR DESCRIPTION
Introduce WorkspaceWorkItemQueryParams with group_by, sub_group_by, and sub_issue fields. Add GroupedPaginatedWorkItemResponse and SubGroupedPaginatedWorkItemResponse models; list_workspace now dispatches to the correct response type based on grouped_by/sub_grouped_by keys returned by the server. Also removes the duplicate list_workspace method.

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace work item queries now support grouping and sub-grouping operations on customizable fields
  * API automatically returns appropriately structured responses based on applied grouping parameters
  * Enhanced workspace-wide item listing with flexible filtering and grouping options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->