### PR TITLE
chore: work item count api response

### DIFF
--- a/plane/api/work_items/base.py
+++ b/plane/api/work_items/base.py
@@ -284,9 +284,9 @@ class WorkItems(BaseResource):
         ISO-date strings for ``target_date`` / ``start_date``.  ``"None"`` is
         used for work items with no value in that dimension.
 
-        When only ``group_by`` is supplied each ``grouped_counts`` entry has
-        shape ``{"count": N}``.  When ``sub_group_by`` is also supplied the
-        shape becomes ``{"total_count": N, "sub_grouped_counts": {sub_key: {"count": N}}}``.
+        Each ``grouped_counts`` entry always has ``count``.  When
+        ``sub_group_by`` is also supplied it additionally carries
+        ``sub_grouped_counts``, a dict mapping sub-group keys to ``{"count": N}``.
 
         Args:
             workspace_slug: The workspace slug identifier
@@ -323,7 +323,7 @@ class WorkItems(BaseResource):
                 ),
             )
             for group, entry in result.grouped_counts.items():
-                print(f"{group}: {entry.total_count} total")
+                print(f"{group}: {entry.count} total")
                 for sub_group, sub_entry in (entry.sub_grouped_counts or {}).items():
                     print(f"  {sub_group}: {sub_entry.count}")
 

--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -611,15 +611,13 @@ class WorkItemGroupCountEntry(BaseModel):
 
     * **Flat** (``group_by`` only): ``{"count": N}``
     * **Nested** (``group_by`` + ``sub_group_by``):
-      ``{"total_count": N, "sub_grouped_counts": {sub_key: {"count": N}}}``
+      ``{"count": N, "sub_grouped_counts": {sub_key: {"count": N}}}``
     """
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    # flat grouped shape (group_by only)
-    count: int | None = None
-    # sub-grouped shape (group_by + sub_group_by)
-    total_count: int | None = None
+    count: int
+
     sub_grouped_counts: dict[str, WorkItemSubGroupCountEntry] | None = None
 
 
@@ -641,7 +639,7 @@ class WorkItemGroupedCountResponse(BaseModel):
             "grouped_counts": {"urgent": {"count": 3}, "None": {"count": 6}}
         }
 
-    **With** ``group_by`` and ``sub_group_by`` — values carry ``total_count``
+    **With** ``group_by`` and ``sub_group_by`` — values carry ``count``
     and a nested ``sub_grouped_counts`` dict::
 
         {
@@ -650,7 +648,7 @@ class WorkItemGroupedCountResponse(BaseModel):
             "total_count": 42,
             "grouped_counts": {
                 "urgent": {
-                    "total_count": 3,
+                    "count": 3,
                     "sub_grouped_counts": {
                         "949645da-a9dd-4a90-94b0-6c8fa16245ee": {"count": 2},
                         "94d35657-a48c-44fd-bed8-87d895386ba4": {"count": 1}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plane-sdk"
-version = "0.2.16"
+version = "0.2.17"
 description = "Python SDK for Plane API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request standardizes the API response format for work item group counts by always using the key `count` (instead of sometimes using `total_count`) in both flat and nested groupings. This change ensures consistency in the response structure and updates related documentation, type definitions, and print statements accordingly.

**API response and model consistency:**

* The `WorkItemGroupCountEntry` model now always uses the `count` field for group counts, removing the previously used `total_count` field. This applies to both flat (single group) and nested (group + sub-group) responses.
* The API documentation and docstrings in `plane/api/work_items/base.py` and `plane/models/work_items.py` have been updated to reflect the consistent use of `count` in all cases. [[1]](diffhunk://#diff-ecf186c62d1db5518d45b91fa091bc0aa229140f9206df5501525e82a6abf9c2L287-R289) [[2]](diffhunk://#diff-b154255f783e23cbe9bf53e99b553767d67dcc04176ae3bf6ede60b9c5d1d316L644-R642)
* Example API responses and code comments now consistently show `count` instead of `total_count` for both top-level and nested group counts.
* Print statements in `count_workspace` now reference `entry.count` instead of `entry.total_count` to match the updated model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the response structure for grouped work item counts. Count values in sub-grouped entries are now consistently structured.

* **Documentation**
  * Updated API documentation to reflect the current grouped count response format and field structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->