### PR TITLE
feat: Add lite list endpoints, project role distribution, and cycle status filtering to the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,26 @@ cycle = client.cycles.create(
 # List cycles
 cycles = client.cycles.list(workspace_slug, project_id)
 
+# Filter cycles by status: current | upcoming | completed | draft | incomplete.
+# `status` is canonical; `cycle_view` is a deprecated alias (status wins if both set).
+from plane.models.query_params import CycleListQueryParams
+
+upcoming = client.cycles.list(
+    workspace_slug, project_id,
+    params=CycleListQueryParams(status="upcoming"),
+)
+for c in upcoming.results:  # paginated envelope
+    print(c.name)
+
+# NOTE: status="current" is a special case — the API returns a BARE LIST of cycles
+# (not the paginated envelope). list() returns whichever shape the server sends.
+current = client.cycles.list(
+    workspace_slug, project_id,
+    params=CycleListQueryParams(status="current"),
+)
+for c in current:  # plain list[Cycle]
+    print(c.name)
+
 # Retrieve a cycle
 cycle = client.cycles.retrieve(workspace_slug, project_id, cycle_id)
 
@@ -525,13 +545,14 @@ client.cycles.delete(workspace_slug, project_id, cycle_id)
 archived = client.cycles.list_archived(workspace_slug, project_id)
 
 # Paginated "lite" cycle list (full cycle fields minus issue-count metrics).
-# Supports a cycle_view status filter: current | upcoming | completed | draft |
-# incomplete (omit for all). Unlike the full list endpoint, this always paginates.
+# Supports a status filter: current | upcoming | completed | draft | incomplete
+# (omit for all). The lite endpoint takes only `status` (no `cycle_view` alias)
+# and ALWAYS paginates — even for status="current".
 from plane.models.query_params import CycleLiteListQueryParams
 
 lite = client.cycles.list_lite(
     workspace_slug, project_id,
-    params=CycleLiteListQueryParams(cycle_view="current", per_page=1000),
+    params=CycleLiteListQueryParams(status="current", per_page=1000),
 )
 for c in lite.results:
     print(c.name)

--- a/README.md
+++ b/README.md
@@ -293,6 +293,13 @@ while paginated_members.next_page_results:
         params=MemberListQueryParams(per_page=1000, cursor=paginated_members.next_cursor),
     )
     all_members.extend(paginated_members.results)
+
+# Project-role distribution — member counts per role across all active
+# (non-archived) projects in the workspace (built-in + custom roles)
+distribution = client.workspaces.get_project_role_distribution(workspace_slug)
+print(distribution.total_memberships, distribution.total_distinct_members)
+for role in distribution.roles:
+    print(role.slug, role.membership_count, role.distinct_member_count)
 ```
 
 #### Roles
@@ -371,6 +378,24 @@ members = client.projects.get_members(
 members = client.projects.get_members_lite(
     workspace_slug, project_id,
     params=MemberListQueryParams(per_page=1000),
+)
+
+# Paginated "lite" project list (id, identifier, name, icon/emoji, description,
+# cover image, archived_at) — for pickers/reference lookups.
+from plane.models.query_params import ProjectLiteListQueryParams
+
+lite = client.projects.list_lite(
+    workspace_slug,
+    params=ProjectLiteListQueryParams(per_page=1000, order_by="-created_at"),
+)
+for p in lite.results:
+    print(p.identifier, p.name)
+
+# NOTE: archived projects are now EXCLUDED by default. Pass include_archived=True
+# to restore the previous behavior of listing archived projects too.
+lite = client.projects.list_lite(
+    workspace_slug,
+    params=ProjectLiteListQueryParams(include_archived=True),
 )
 ```
 
@@ -499,6 +524,18 @@ client.cycles.delete(workspace_slug, project_id, cycle_id)
 # List archived cycles
 archived = client.cycles.list_archived(workspace_slug, project_id)
 
+# Paginated "lite" cycle list (full cycle fields minus issue-count metrics).
+# Supports a cycle_view status filter: current | upcoming | completed | draft |
+# incomplete (omit for all). Unlike the full list endpoint, this always paginates.
+from plane.models.query_params import CycleLiteListQueryParams
+
+lite = client.cycles.list_lite(
+    workspace_slug, project_id,
+    params=CycleLiteListQueryParams(cycle_view="current", per_page=1000),
+)
+for c in lite.results:
+    print(c.name)
+
 # Add work items to cycle
 from plane.models.cycles import AddWorkItemsToCycleRequest
 
@@ -556,6 +593,16 @@ client.modules.delete(workspace_slug, project_id, module_id)
 
 # List archived modules
 archived = client.modules.list_archived(workspace_slug, project_id)
+
+# Paginated "lite" module list (full module fields minus issue-count metrics)
+from plane.models.query_params import LiteListQueryParams
+
+lite = client.modules.list_lite(
+    workspace_slug, project_id,
+    params=LiteListQueryParams(per_page=1000, order_by="-created_at"),
+)
+for m in lite.results:
+    print(m.name)
 
 # Add work items to module
 from plane.models.modules import AddWorkItemsToModuleRequest

--- a/plane/api/cycles.py
+++ b/plane/api/cycles.py
@@ -5,12 +5,13 @@ from ..models.cycles import (
     CreateCycle,
     Cycle,
     PaginatedArchivedCycleResponse,
+    PaginatedCycleLiteResponse,
     PaginatedCycleResponse,
     PaginatedCycleWorkItemResponse,
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from ..models.query_params import WorkItemQueryParams
+from ..models.query_params import LiteListQueryParams, WorkItemQueryParams
 from .base_resource import BaseResource
 from .work_items.base import prepare_work_item_params
 
@@ -83,6 +84,31 @@ class Cycles(BaseResource):
         """
         response = self._get(f"{workspace_slug}/projects/{project_id}/cycles", params=params)
         return PaginatedCycleResponse.model_validate(response)
+
+    def list_lite(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        params: LiteListQueryParams | None = None,
+    ) -> PaginatedCycleLiteResponse:
+        """List cycles as a paginated "lite" response.
+
+        Calls the read-only ``/cycles-lite/`` endpoint, which returns the full
+        cycle field set minus the issue-count metric annotations (total_issues,
+        completed_issues, etc.), suitable for pickers and reference lookups.
+        Only ordering and cursor pagination are supported -- there are no field
+        filters. ``per_page`` defaults to and caps at 1000.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            params: Optional ordering + cursor pagination query parameters
+        """
+        query_params = params.model_dump(exclude_none=True) if params else None
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/cycles-lite", params=query_params
+        )
+        return PaginatedCycleLiteResponse.model_validate(response)
 
     def list_archived(
         self, workspace_slug: str, project_id: str, params: Mapping[str, Any] | None = None

--- a/plane/api/cycles.py
+++ b/plane/api/cycles.py
@@ -11,7 +11,7 @@ from ..models.cycles import (
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from ..models.query_params import LiteListQueryParams, WorkItemQueryParams
+from ..models.query_params import CycleLiteListQueryParams, WorkItemQueryParams
 from .base_resource import BaseResource
 from .work_items.base import prepare_work_item_params
 
@@ -89,24 +89,29 @@ class Cycles(BaseResource):
         self,
         workspace_slug: str,
         project_id: str,
-        params: LiteListQueryParams | None = None,
+        params: CycleLiteListQueryParams | None = None,
     ) -> PaginatedCycleLiteResponse:
         """List cycles as a paginated "lite" response.
 
         Calls the read-only ``/cycles-lite/`` endpoint, which returns the full
         cycle field set minus the issue-count metric annotations (total_issues,
         completed_issues, etc.), suitable for pickers and reference lookups.
-        Only ordering and cursor pagination are supported -- there are no field
-        filters. ``per_page`` defaults to and caps at 1000.
+        Supports ordering, cursor pagination, and a ``cycle_view`` status filter
+        -- there are no field filters. ``per_page`` defaults to and caps at 1000.
+
+        Unlike the full ``cycles`` list endpoint (where ``cycle_view=current``
+        returns a bare array), this endpoint always returns the paginated
+        envelope for every ``cycle_view`` value.
 
         Args:
             workspace_slug: The workspace slug identifier
             project_id: UUID of the project
-            params: Optional ordering + cursor pagination query parameters
+            params: Optional ordering + cursor pagination query parameters,
+                plus the ``cycle_view`` status filter
         """
-        query_params = params.model_dump(exclude_none=True) if params else None
         response = self._get(
-            f"{workspace_slug}/projects/{project_id}/cycles-lite", params=query_params
+            f"{workspace_slug}/projects/{project_id}/cycles-lite",
+            params=params.to_query_params() if params else None,
         )
         return PaginatedCycleLiteResponse.model_validate(response)
 

--- a/plane/api/cycles.py
+++ b/plane/api/cycles.py
@@ -11,7 +11,11 @@ from ..models.cycles import (
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from ..models.query_params import CycleLiteListQueryParams, WorkItemQueryParams
+from ..models.query_params import (
+    CycleListQueryParams,
+    CycleLiteListQueryParams,
+    WorkItemQueryParams,
+)
 from .base_resource import BaseResource
 from .work_items.base import prepare_work_item_params
 
@@ -73,16 +77,39 @@ class Cycles(BaseResource):
         return self._delete(f"{workspace_slug}/projects/{project_id}/cycles/{cycle_id}")
 
     def list(
-        self, workspace_slug: str, project_id: str, params: Mapping[str, Any] | None = None
-    ) -> PaginatedCycleResponse:
+        self,
+        workspace_slug: str,
+        project_id: str,
+        params: CycleListQueryParams | Mapping[str, Any] | None = None,
+    ) -> PaginatedCycleResponse | list[Cycle]:
         """List cycles with optional filtering parameters.
+
+        Supports cycle status filtering via :class:`CycleListQueryParams`. Pass
+        ``status`` (canonical) or the deprecated ``cycle_view`` alias with one of
+        ``current``, ``upcoming``, ``completed``, ``draft``, ``incomplete``; if
+        both are supplied the server uses ``status``.
+
+        .. note::
+            With ``status=current`` (or ``cycle_view=current``) the server
+            returns a **bare list** of :class:`Cycle` objects instead of the
+            paginated :class:`PaginatedCycleResponse` envelope returned for all
+            other values. This method returns whichever shape the server sends.
+            The :meth:`list_lite` endpoint always paginates, even for
+            ``status=current``.
 
         Args:
             workspace_slug: The workspace slug identifier
             project_id: UUID of the project
-            params: Optional query parameters
+            params: Optional query parameters. Prefer ``CycleListQueryParams``;
+                a plain mapping is also accepted for backwards compatibility.
         """
-        response = self._get(f"{workspace_slug}/projects/{project_id}/cycles", params=params)
+        if isinstance(params, CycleListQueryParams):
+            query_params: Mapping[str, Any] | None = params.to_query_params()
+        else:
+            query_params = params
+        response = self._get(f"{workspace_slug}/projects/{project_id}/cycles", params=query_params)
+        if isinstance(response, list):
+            return [Cycle.model_validate(item) for item in response]
         return PaginatedCycleResponse.model_validate(response)
 
     def list_lite(
@@ -96,18 +123,20 @@ class Cycles(BaseResource):
         Calls the read-only ``/cycles-lite/`` endpoint, which returns the full
         cycle field set minus the issue-count metric annotations (total_issues,
         completed_issues, etc.), suitable for pickers and reference lookups.
-        Supports ordering, cursor pagination, and a ``cycle_view`` status filter
-        -- there are no field filters. ``per_page`` defaults to and caps at 1000.
+        Supports ordering, cursor pagination, and a ``status`` filter -- there
+        are no field filters. ``per_page`` defaults to and caps at 1000. Unlike
+        the full cycles list, the lite endpoint accepts only ``status`` (no
+        ``cycle_view`` alias).
 
-        Unlike the full ``cycles`` list endpoint (where ``cycle_view=current``
+        Unlike the full ``cycles`` list endpoint (where ``status=current``
         returns a bare array), this endpoint always returns the paginated
-        envelope for every ``cycle_view`` value.
+        envelope for every ``status`` value.
 
         Args:
             workspace_slug: The workspace slug identifier
             project_id: UUID of the project
             params: Optional ordering + cursor pagination query parameters,
-                plus the ``cycle_view`` status filter
+                plus the ``status`` filter
         """
         response = self._get(
             f"{workspace_slug}/projects/{project_id}/cycles-lite",

--- a/plane/api/modules.py
+++ b/plane/api/modules.py
@@ -5,11 +5,12 @@ from ..models.modules import (
     CreateModule,
     Module,
     PaginatedArchivedModuleResponse,
+    PaginatedModuleLiteResponse,
     PaginatedModuleResponse,
     PaginatedModuleWorkItemResponse,
     UpdateModule,
 )
-from ..models.query_params import WorkItemQueryParams
+from ..models.query_params import LiteListQueryParams, WorkItemQueryParams
 from .base_resource import BaseResource
 from .work_items.base import prepare_work_item_params
 
@@ -82,6 +83,31 @@ class Modules(BaseResource):
         """
         response = self._get(f"{workspace_slug}/projects/{project_id}/modules", params=params)
         return PaginatedModuleResponse.model_validate(response)
+
+    def list_lite(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        params: LiteListQueryParams | None = None,
+    ) -> PaginatedModuleLiteResponse:
+        """List modules as a paginated "lite" response.
+
+        Calls the read-only ``/modules-lite/`` endpoint, which returns the full
+        module field set minus the issue-count metric annotations (total_issues,
+        completed_issues, etc.), suitable for pickers and reference lookups.
+        Only ordering and cursor pagination are supported -- there are no field
+        filters. ``per_page`` defaults to and caps at 1000.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            project_id: UUID of the project
+            params: Optional ordering + cursor pagination query parameters
+        """
+        query_params = params.model_dump(exclude_none=True) if params else None
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/modules-lite", params=query_params
+        )
+        return PaginatedModuleLiteResponse.model_validate(response)
 
     def list_archived(
         self, workspace_slug: str, project_id: str, params: Mapping[str, Any] | None = None

--- a/plane/api/modules.py
+++ b/plane/api/modules.py
@@ -103,9 +103,9 @@ class Modules(BaseResource):
             project_id: UUID of the project
             params: Optional ordering + cursor pagination query parameters
         """
-        query_params = params.model_dump(exclude_none=True) if params else None
         response = self._get(
-            f"{workspace_slug}/projects/{project_id}/modules-lite", params=query_params
+            f"{workspace_slug}/projects/{project_id}/modules-lite",
+            params=params.to_query_params() if params else None,
         )
         return PaginatedModuleLiteResponse.model_validate(response)
 

--- a/plane/api/projects.py
+++ b/plane/api/projects.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ..models.projects import (
     CreateProject,
+    PaginatedProjectLiteResponse,
     PaginatedProjectMemberResponse,
     PaginatedProjectResponse,
     Project,
@@ -14,6 +15,7 @@ from ..models.projects import (
     UpdateProject,
 )
 from ..models.query_params import (
+    LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
@@ -79,6 +81,25 @@ class Projects(BaseResource):
         query_params = params.model_dump(exclude_none=True) if params else None
         response = self._get(f"{workspace_slug}/projects", params=query_params)
         return PaginatedProjectResponse.model_validate(response)
+
+    def list_lite(
+        self, workspace_slug: str, params: LiteListQueryParams | None = None
+    ) -> PaginatedProjectLiteResponse:
+        """List projects as a paginated "lite" response.
+
+        Calls the read-only ``/projects-lite/`` endpoint, which returns a
+        field-trimmed shape (id, identifier, name, cover_image, icon_prop,
+        emoji, description, cover_image_url) suitable for pickers and reference
+        lookups. Only ordering and cursor pagination are supported -- there are
+        no field filters. ``per_page`` defaults to and caps at 1000.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+            params: Optional ordering + cursor pagination query parameters
+        """
+        query_params = params.model_dump(exclude_none=True) if params else None
+        response = self._get(f"{workspace_slug}/projects-lite", params=query_params)
+        return PaginatedProjectLiteResponse.model_validate(response)
 
     def get_worklog_summary(self, workspace_slug: str, project_id: str) -> [ProjectWorklogSummary]:
         """Get work log summary for a project.

--- a/plane/api/projects.py
+++ b/plane/api/projects.py
@@ -15,10 +15,10 @@ from ..models.projects import (
     UpdateProject,
 )
 from ..models.query_params import (
-    LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
+    ProjectLiteListQueryParams,
 )
 from .base_resource import BaseResource
 
@@ -83,22 +83,31 @@ class Projects(BaseResource):
         return PaginatedProjectResponse.model_validate(response)
 
     def list_lite(
-        self, workspace_slug: str, params: LiteListQueryParams | None = None
+        self, workspace_slug: str, params: ProjectLiteListQueryParams | None = None
     ) -> PaginatedProjectLiteResponse:
         """List projects as a paginated "lite" response.
 
         Calls the read-only ``/projects-lite/`` endpoint, which returns a
         field-trimmed shape (id, identifier, name, cover_image, icon_prop,
-        emoji, description, cover_image_url) suitable for pickers and reference
-        lookups. Only ordering and cursor pagination are supported -- there are
-        no field filters. ``per_page`` defaults to and caps at 1000.
+        emoji, description, cover_image_url, archived_at) suitable for pickers
+        and reference lookups. Supports ordering, cursor pagination, and an
+        ``include_archived`` toggle -- there are no field filters. ``per_page``
+        defaults to and caps at 1000.
+
+        .. note::
+            Archived projects are now **excluded** by default. Pass
+            ``ProjectLiteListQueryParams(include_archived=True)`` to restore the
+            previous behavior of listing archived projects too.
 
         Args:
             workspace_slug: The workspace slug identifier
-            params: Optional ordering + cursor pagination query parameters
+            params: Optional ordering + cursor pagination query parameters,
+                plus the ``include_archived`` toggle
         """
-        query_params = params.model_dump(exclude_none=True) if params else None
-        response = self._get(f"{workspace_slug}/projects-lite", params=query_params)
+        response = self._get(
+            f"{workspace_slug}/projects-lite",
+            params=params.to_query_params() if params else None,
+        )
         return PaginatedProjectLiteResponse.model_validate(response)
 
     def get_worklog_summary(self, workspace_slug: str, project_id: str) -> [ProjectWorklogSummary]:

--- a/plane/api/workspaces.py
+++ b/plane/api/workspaces.py
@@ -5,6 +5,7 @@ from typing import Any
 from ..models.query_params import MemberListQueryParams, MemberQueryParams
 from ..models.workspaces import (
     PaginatedWorkspaceMemberResponse,
+    ProjectRoleDistribution,
     WorkspaceFeature,
     WorkspaceMember,
 )
@@ -53,6 +54,19 @@ class Workspaces(BaseResource):
             params=params.to_query_params() if params else None,
         )
         return PaginatedWorkspaceMemberResponse.model_validate(response)
+
+    def get_project_role_distribution(self, workspace_slug: str) -> ProjectRoleDistribution:
+        """Get the distribution of project members by role across the workspace.
+
+        Aggregates member counts per role over all active (non-archived)
+        projects in the workspace. Both built-in roles (admin, contributor,
+        commenter, guest) and custom roles are included.
+
+        Args:
+            workspace_slug: The workspace slug identifier
+        """
+        response = self._get(f"{workspace_slug}/project-role-distribution")
+        return ProjectRoleDistribution.model_validate(response)
 
     def get_features(self, workspace_slug: str) -> WorkspaceFeature:
         """Get features of a workspace.

--- a/plane/models/__init__.py
+++ b/plane/models/__init__.py
@@ -15,10 +15,12 @@ from .enums import (
 )
 from .query_params import (
     BaseQueryParams,
+    CycleLiteListQueryParams,
     LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
+    ProjectLiteListQueryParams,
     RetrieveQueryParams,
     WorkItemQueryParams,
 )
@@ -40,10 +42,12 @@ __all__ = [
     "IntakeWorkItemStatusEnum",
     # query params
     "BaseQueryParams",
+    "CycleLiteListQueryParams",
     "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",
     "PaginatedQueryParams",
+    "ProjectLiteListQueryParams",
     "RetrieveQueryParams",
     "WorkItemQueryParams",
 ]

--- a/plane/models/__init__.py
+++ b/plane/models/__init__.py
@@ -15,6 +15,7 @@ from .enums import (
 )
 from .query_params import (
     BaseQueryParams,
+    LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
@@ -39,6 +40,7 @@ __all__ = [
     "IntakeWorkItemStatusEnum",
     # query params
     "BaseQueryParams",
+    "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",
     "PaginatedQueryParams",

--- a/plane/models/__init__.py
+++ b/plane/models/__init__.py
@@ -16,6 +16,7 @@ from .enums import (
 from .query_params import (
     BaseQueryParams,
     CycleLiteListQueryParams,
+    CycleListQueryParams,
     LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
@@ -43,6 +44,7 @@ __all__ = [
     # query params
     "BaseQueryParams",
     "CycleLiteListQueryParams",
+    "CycleListQueryParams",
     "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",

--- a/plane/models/cycles.py
+++ b/plane/models/cycles.py
@@ -141,6 +141,14 @@ class PaginatedCycleResponse(PaginatedResponse):
     results: list[Cycle]
 
 
+class PaginatedCycleLiteResponse(PaginatedResponse):
+    """Paginated response for the cycles-lite endpoint."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: list[CycleLite]
+
+
 class PaginatedArchivedCycleResponse(PaginatedResponse):
     """Paginated response for archived cycles."""
 

--- a/plane/models/enums.py
+++ b/plane/models/enums.py
@@ -48,7 +48,10 @@ PropertyTypeEnum = Literal[
     "FORMULA",
 ]
 RelationTypeEnum = Literal["ISSUE", "USER", "RELEASE"]
-CycleViewEnum = Literal["current", "upcoming", "completed", "draft", "incomplete"]
+CycleStatusEnum = Literal["current", "upcoming", "completed", "draft", "incomplete"]
+# Deprecated alias for CycleStatusEnum. ``status`` is the canonical cycle filter
+# going forward; ``cycle_view`` is kept only for backward compatibility.
+CycleViewEnum = CycleStatusEnum
 
 
 # Proper Enum classes for better type safety and IDE support
@@ -582,6 +585,7 @@ __all__ = [
     "PriorityEnum",
     "PropertyTypeEnum",
     "RelationTypeEnum",
+    "CycleStatusEnum",
     "CycleViewEnum",
     "TimezoneEnum",
     "TypeMimeEnum",

--- a/plane/models/enums.py
+++ b/plane/models/enums.py
@@ -48,6 +48,7 @@ PropertyTypeEnum = Literal[
     "FORMULA",
 ]
 RelationTypeEnum = Literal["ISSUE", "USER", "RELEASE"]
+CycleViewEnum = Literal["current", "upcoming", "completed", "draft", "incomplete"]
 
 
 # Proper Enum classes for better type safety and IDE support
@@ -92,6 +93,7 @@ class InitiativeState(Enum):
     ACTIVE = "ACTIVE"
     COMPLETED = "COMPLETED"
     CLOSED = "CLOSED"
+
 
 class WorkItemRelationType(Enum):
     """Work item relation type enumeration."""
@@ -580,6 +582,7 @@ __all__ = [
     "PriorityEnum",
     "PropertyTypeEnum",
     "RelationTypeEnum",
+    "CycleViewEnum",
     "TimezoneEnum",
     "TypeMimeEnum",
     "NetworkEnum",

--- a/plane/models/modules.py
+++ b/plane/models/modules.py
@@ -132,6 +132,14 @@ class PaginatedModuleResponse(PaginatedResponse):
     results: list[Module]
 
 
+class PaginatedModuleLiteResponse(PaginatedResponse):
+    """Paginated response for the modules-lite endpoint."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: list[ModuleLite]
+
+
 class PaginatedArchivedModuleResponse(PaginatedResponse):
     """Paginated response for archived modules."""
 

--- a/plane/models/projects.py
+++ b/plane/models/projects.py
@@ -75,6 +75,7 @@ class ProjectLite(BaseModel):
     emoji: str | None = None
     description: str | None = None
     cover_image_url: str | None = None
+    archived_at: str | None = None
 
 
 class CreateProject(BaseModel):

--- a/plane/models/projects.py
+++ b/plane/models/projects.py
@@ -58,6 +58,25 @@ class Project(BaseModel):
     default_state: str | None = None
 
 
+class ProjectLite(BaseModel):
+    """Lite project information.
+
+    Trimmed shape returned by the read-only ``projects-lite`` list endpoint
+    (``ProjectLiteSerializer``), intended for pickers and reference lookups.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    identifier: str
+    name: str
+    cover_image: str | None = None
+    icon_prop: Any | None = None
+    emoji: str | None = None
+    description: str | None = None
+    cover_image_url: str | None = None
+
+
 class CreateProject(BaseModel):
     """Request model for creating a project."""
 
@@ -136,6 +155,14 @@ class PaginatedProjectResponse(PaginatedResponse):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     results: list[Project]
+
+
+class PaginatedProjectLiteResponse(PaginatedResponse):
+    """Paginated response for the projects-lite endpoint."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    results: list[ProjectLite]
 
 
 class ProjectMember(UserLite):

--- a/plane/models/query_params.py
+++ b/plane/models/query_params.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .enums import CycleViewEnum
+from .enums import CycleStatusEnum
 
 
 class BaseQueryParams(BaseModel):
@@ -212,24 +212,53 @@ class ProjectLiteListQueryParams(LiteListQueryParams):
     )
 
 
+_CYCLE_STATUS_DESCRIPTION = (
+    "Filter cycles by status: 'current' (started, not yet ended), 'upcoming' "
+    "(starts in the future), 'completed' (ended), 'draft' (no start/end dates), "
+    "or 'incomplete' (not yet finished or open-ended). Omit to return all cycles."
+)
+
+
 class CycleLiteListQueryParams(LiteListQueryParams):
     """Query parameters for the cycles-lite list endpoint.
 
-    Adds the ``cycle_view`` status filter to the shared lite ordering + cursor
-    pagination params.
+    Adds the ``status`` filter to the shared lite ordering + cursor pagination
+    params. Unlike the full cycles list, the lite endpoint accepts only
+    ``status`` (no ``cycle_view`` alias) and always returns a paginated envelope.
     """
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    cycle_view: CycleViewEnum | None = Field(
+    status: CycleStatusEnum | None = Field(None, description=_CYCLE_STATUS_DESCRIPTION)
+
+
+class CycleListQueryParams(PaginatedQueryParams):
+    """Query parameters for the full cycles list endpoint.
+
+    Adds cycle status filtering on top of the standard pagination params.
+    ``status`` is the canonical filter; ``cycle_view`` is a deprecated alias kept
+    for backward compatibility. If both are sent, the server uses ``status`` and
+    ignores ``cycle_view``.
+
+    Note: with ``status=current`` (or ``cycle_view=current``) the server returns
+    a bare array of cycles rather than the paginated envelope returned for all
+    other values. :meth:`~plane.api.cycles.Cycles.list` handles both shapes.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    status: CycleStatusEnum | None = Field(None, description=_CYCLE_STATUS_DESCRIPTION)
+    cycle_view: CycleStatusEnum | None = Field(
         None,
         description=(
-            "Filter cycles by status: 'current' (started, not yet ended), "
-            "'upcoming' (starts in the future), 'completed' (ended), 'draft' "
-            "(no start/end dates), or 'incomplete' (not yet finished or "
-            "open-ended). Omit to return all cycles."
+            "Deprecated alias for ``status``, kept for backward compatibility. "
+            "Prefer ``status``; if both are supplied the server uses ``status``."
         ),
     )
+
+    def to_query_params(self) -> dict[str, Any]:
+        """Serialize to a query-param dict, dropping unset fields."""
+        return self.model_dump(exclude_none=True)
 
 
 WorkItemCountGroupBy = Literal[
@@ -299,6 +328,7 @@ class WorkItemCountQueryParams(BaseModel):
 __all__ = [
     "BaseQueryParams",
     "CycleLiteListQueryParams",
+    "CycleListQueryParams",
     "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",

--- a/plane/models/query_params.py
+++ b/plane/models/query_params.py
@@ -4,6 +4,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .enums import CycleViewEnum
+
 
 class BaseQueryParams(BaseModel):
     """Base query parameters for API requests."""
@@ -180,6 +182,55 @@ class LiteListQueryParams(BaseModel):
         description="Field to order results by. Prefix with '-' for descending order",
     )
 
+    def to_query_params(self) -> dict[str, Any]:
+        """Serialize to a query-param dict the lite endpoints accept.
+
+        Booleans are rendered as lowercase ``"true"``/``"false"`` strings so the
+        backend parses them (a Python ``True`` would be encoded as ``"True"`` and
+        rejected). Unset fields are dropped so they never reach the query string.
+        """
+        raw = self.model_dump(exclude_none=True)
+        return {k: (str(v).lower() if isinstance(v, bool) else v) for k, v in raw.items()}
+
+
+class ProjectLiteListQueryParams(LiteListQueryParams):
+    """Query parameters for the projects-lite list endpoint.
+
+    Adds the ``include_archived`` toggle to the shared lite ordering + cursor
+    pagination params.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    include_archived: bool | None = Field(
+        None,
+        description=(
+            "Include archived projects in the results. Defaults to False on the "
+            "server, which excludes archived projects. Set True to restore the "
+            "previous behavior of listing archived projects too."
+        ),
+    )
+
+
+class CycleLiteListQueryParams(LiteListQueryParams):
+    """Query parameters for the cycles-lite list endpoint.
+
+    Adds the ``cycle_view`` status filter to the shared lite ordering + cursor
+    pagination params.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    cycle_view: CycleViewEnum | None = Field(
+        None,
+        description=(
+            "Filter cycles by status: 'current' (started, not yet ended), "
+            "'upcoming' (starts in the future), 'completed' (ended), 'draft' "
+            "(no start/end dates), or 'incomplete' (not yet finished or "
+            "open-ended). Omit to return all cycles."
+        ),
+    )
+
 
 WorkItemCountGroupBy = Literal[
     "state_id",
@@ -247,9 +298,11 @@ class WorkItemCountQueryParams(BaseModel):
 
 __all__ = [
     "BaseQueryParams",
+    "CycleLiteListQueryParams",
     "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",
+    "ProjectLiteListQueryParams",
     "PaginatedQueryParams",
     "RetrieveQueryParams",
     "WorkItemCountGroupBy",

--- a/plane/models/query_params.py
+++ b/plane/models/query_params.py
@@ -154,6 +154,33 @@ class MemberListQueryParams(MemberQueryParams):
     )
 
 
+class LiteListQueryParams(BaseModel):
+    """Query parameters for the read-only "lite" list endpoints.
+
+    The lite list routes (``projects-lite``, ``cycles-lite``, ``modules-lite``)
+    support only ordering and cursor pagination -- they expose no field filters.
+    ``per_page`` defaults to and caps at 1000 on the server.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    cursor: str | None = Field(
+        None,
+        description='Pagination cursor of the form "{per_page}:{page}:{offset}", '
+        "e.g. 1000:0:0. Use the response's next_cursor to fetch the next page.",
+    )
+    per_page: int | None = Field(
+        None,
+        description="Number of results per page (default and max 1000)",
+        ge=1,
+        le=1000,
+    )
+    order_by: str | None = Field(
+        None,
+        description="Field to order results by. Prefix with '-' for descending order",
+    )
+
+
 WorkItemCountGroupBy = Literal[
     "state_id",
     "state__group",
@@ -220,6 +247,7 @@ class WorkItemCountQueryParams(BaseModel):
 
 __all__ = [
     "BaseQueryParams",
+    "LiteListQueryParams",
     "MemberListQueryParams",
     "MemberQueryParams",
     "PaginatedQueryParams",

--- a/plane/models/workspaces.py
+++ b/plane/models/workspaces.py
@@ -37,3 +37,31 @@ class WorkspaceFeature(BaseModel):
     customers: bool
     wiki: bool
     pi: bool
+
+
+class ProjectRoleDistributionEntry(BaseModel):
+    """Per-role membership counts within a workspace's project-role distribution."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    role_id: str | None = None
+    name: str | None = None
+    slug: str | None = None
+    is_system: bool | None = None
+    level: int | None = None
+    membership_count: int | None = None
+    distinct_member_count: int | None = None
+
+
+class ProjectRoleDistribution(BaseModel):
+    """Aggregate count of project members by role across a workspace.
+
+    Counts span all active (non-archived) projects in the workspace and include
+    both built-in roles (admin, contributor, commenter, guest) and custom roles.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    total_memberships: int | None = None
+    total_distinct_members: int | None = None
+    roles: list[ProjectRoleDistributionEntry] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plane-sdk"
-version = "0.2.18"
+version = "0.2.19"
 description = "Python SDK for Plane API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cycles.py
+++ b/tests/unit/test_cycles.py
@@ -7,7 +7,7 @@ import pytest
 from plane.client import PlaneClient
 from plane.models.cycles import CreateCycle, CycleLite, UpdateCycle
 from plane.models.projects import Project, ProjectFeature
-from plane.models.query_params import LiteListQueryParams
+from plane.models.query_params import CycleLiteListQueryParams
 
 
 class TestCyclesAPI:
@@ -27,12 +27,23 @@ class TestCyclesAPI:
         self, client: PlaneClient, workspace_slug: str, project: Project
     ) -> None:
         """list_lite returns a paginated envelope of CycleLite items."""
-        params = LiteListQueryParams(per_page=5, order_by="-created_at")
+        params = CycleLiteListQueryParams(per_page=5, order_by="-created_at")
         response = client.cycles.list_lite(workspace_slug, project.id, params=params)
         assert isinstance(response.results, list)
         assert isinstance(response.total_count, int)
         assert isinstance(response.next_page_results, bool)
         assert len(response.results) <= 5
+        for cycle in response.results:
+            assert isinstance(cycle, CycleLite)
+
+    def test_list_lite_cycle_view(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        """list_lite honors the cycle_view status filter and stays paginated."""
+        params = CycleLiteListQueryParams(cycle_view="current", per_page=5)
+        response = client.cycles.list_lite(workspace_slug, project.id, params=params)
+        assert isinstance(response.results, list)
+        assert isinstance(response.total_count, int)
         for cycle in response.results:
             assert isinstance(cycle, CycleLite)
 

--- a/tests/unit/test_cycles.py
+++ b/tests/unit/test_cycles.py
@@ -5,8 +5,9 @@ from datetime import datetime
 import pytest
 
 from plane.client import PlaneClient
-from plane.models.cycles import CreateCycle, UpdateCycle
+from plane.models.cycles import CreateCycle, CycleLite, UpdateCycle
 from plane.models.projects import Project, ProjectFeature
+from plane.models.query_params import LiteListQueryParams
 
 
 class TestCyclesAPI:
@@ -21,6 +22,19 @@ class TestCyclesAPI:
         assert hasattr(response, "results")
         assert hasattr(response, "count")
         assert isinstance(response.results, list)
+
+    def test_list_lite(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        """list_lite returns a paginated envelope of CycleLite items."""
+        params = LiteListQueryParams(per_page=5, order_by="-created_at")
+        response = client.cycles.list_lite(workspace_slug, project.id, params=params)
+        assert isinstance(response.results, list)
+        assert isinstance(response.total_count, int)
+        assert isinstance(response.next_page_results, bool)
+        assert len(response.results) <= 5
+        for cycle in response.results:
+            assert isinstance(cycle, CycleLite)
 
     def test_list_archived_cycles(
         self, client: PlaneClient, workspace_slug: str, project: Project

--- a/tests/unit/test_cycles.py
+++ b/tests/unit/test_cycles.py
@@ -5,9 +5,9 @@ from datetime import datetime
 import pytest
 
 from plane.client import PlaneClient
-from plane.models.cycles import CreateCycle, CycleLite, UpdateCycle
+from plane.models.cycles import CreateCycle, Cycle, CycleLite, UpdateCycle
 from plane.models.projects import Project, ProjectFeature
-from plane.models.query_params import CycleLiteListQueryParams
+from plane.models.query_params import CycleLiteListQueryParams, CycleListQueryParams
 
 
 class TestCyclesAPI:
@@ -36,16 +36,35 @@ class TestCyclesAPI:
         for cycle in response.results:
             assert isinstance(cycle, CycleLite)
 
-    def test_list_lite_cycle_view(
+    def test_list_lite_status(
         self, client: PlaneClient, workspace_slug: str, project: Project
     ) -> None:
-        """list_lite honors the cycle_view status filter and stays paginated."""
-        params = CycleLiteListQueryParams(cycle_view="current", per_page=5)
+        """list_lite honors the status filter and stays paginated, even for current."""
+        params = CycleLiteListQueryParams(status="current", per_page=5)
         response = client.cycles.list_lite(workspace_slug, project.id, params=params)
         assert isinstance(response.results, list)
         assert isinstance(response.total_count, int)
         for cycle in response.results:
             assert isinstance(cycle, CycleLite)
+
+    def test_list_status_paginated(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        """Full list with a non-current status returns the paginated envelope."""
+        params = CycleListQueryParams(status="upcoming")
+        response = client.cycles.list(workspace_slug, project.id, params=params)
+        assert hasattr(response, "results")
+        assert isinstance(response.results, list)
+
+    def test_list_status_current_returns_bare_list(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        """Full list with status=current returns a bare list of cycles, not an envelope."""
+        params = CycleListQueryParams(status="current")
+        response = client.cycles.list(workspace_slug, project.id, params=params)
+        assert isinstance(response, list)
+        for cycle in response:
+            assert isinstance(cycle, Cycle)
 
     def test_list_archived_cycles(
         self, client: PlaneClient, workspace_slug: str, project: Project

--- a/tests/unit/test_modules.py
+++ b/tests/unit/test_modules.py
@@ -6,8 +6,9 @@ import pytest
 
 from plane.client import PlaneClient
 from plane.models.enums import ModuleStatus
-from plane.models.modules import CreateModule, UpdateModule
+from plane.models.modules import CreateModule, ModuleLite, UpdateModule
 from plane.models.projects import Project, ProjectFeature
+from plane.models.query_params import LiteListQueryParams
 
 
 class TestModulesAPI:
@@ -22,6 +23,19 @@ class TestModulesAPI:
         assert hasattr(response, "results")
         assert hasattr(response, "count")
         assert isinstance(response.results, list)
+
+    def test_list_lite(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        """list_lite returns a paginated envelope of ModuleLite items."""
+        params = LiteListQueryParams(per_page=5, order_by="-created_at")
+        response = client.modules.list_lite(workspace_slug, project.id, params=params)
+        assert isinstance(response.results, list)
+        assert isinstance(response.total_count, int)
+        assert isinstance(response.next_page_results, bool)
+        assert len(response.results) <= 5
+        for module in response.results:
+            assert isinstance(module, ModuleLite)
 
     def test_list_archived_modules(
         self, client: PlaneClient, workspace_slug: str, project: Project

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -13,10 +13,10 @@ from plane.models.projects import (
     UpdateProject,
 )
 from plane.models.query_params import (
-    LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
+    ProjectLiteListQueryParams,
 )
 
 
@@ -52,10 +52,20 @@ class TestProjectsAPI:
 
     def test_list_lite_with_params(self, client: PlaneClient, workspace_slug: str) -> None:
         """list_lite honors ordering + cursor pagination params."""
-        params = LiteListQueryParams(per_page=5, order_by="-created_at")
+        params = ProjectLiteListQueryParams(per_page=5, order_by="-created_at")
         response = client.projects.list_lite(workspace_slug, params=params)
         assert isinstance(response.results, list)
         assert len(response.results) <= 5
+
+    def test_list_lite_include_archived(self, client: PlaneClient, workspace_slug: str) -> None:
+        """list_lite with include_archived=True returns a valid envelope.
+
+        Archived projects are excluded by default; this opt-in restores them.
+        """
+        params = ProjectLiteListQueryParams(include_archived=True, per_page=5)
+        response = client.projects.list_lite(workspace_slug, params=params)
+        assert isinstance(response.results, list)
+        assert isinstance(response.total_count, int)
 
 
 class TestProjectsAPICRUD:

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -5,8 +5,15 @@ from datetime import datetime
 import pytest
 
 from plane.client import PlaneClient
-from plane.models.projects import CreateProject, Project, ProjectMember, UpdateProject
+from plane.models.projects import (
+    CreateProject,
+    Project,
+    ProjectLite,
+    ProjectMember,
+    UpdateProject,
+)
 from plane.models.query_params import (
+    LiteListQueryParams,
     MemberListQueryParams,
     MemberQueryParams,
     PaginatedQueryParams,
@@ -30,6 +37,24 @@ class TestProjectsAPI:
         response = client.projects.list(workspace_slug, params=params)
         assert response is not None
         assert hasattr(response, "results")
+        assert len(response.results) <= 5
+
+    def test_list_lite(self, client: PlaneClient, workspace_slug: str) -> None:
+        """list_lite returns a paginated envelope of ProjectLite items."""
+        response = client.projects.list_lite(workspace_slug)
+        assert isinstance(response.results, list)
+        assert isinstance(response.total_count, int)
+        assert isinstance(response.next_page_results, bool)
+        for project in response.results:
+            assert isinstance(project, ProjectLite)
+            assert project.name is not None
+            assert project.identifier is not None
+
+    def test_list_lite_with_params(self, client: PlaneClient, workspace_slug: str) -> None:
+        """list_lite honors ordering + cursor pagination params."""
+        params = LiteListQueryParams(per_page=5, order_by="-created_at")
+        response = client.projects.list_lite(workspace_slug, params=params)
+        assert isinstance(response.results, list)
         assert len(response.results) <= 5
 
 

--- a/tests/unit/test_workspaces.py
+++ b/tests/unit/test_workspaces.py
@@ -2,7 +2,7 @@
 
 from plane.client import PlaneClient
 from plane.models.query_params import MemberListQueryParams, MemberQueryParams
-from plane.models.workspaces import WorkspaceMember
+from plane.models.workspaces import ProjectRoleDistributionEntry, WorkspaceMember
 
 
 class TestWorkspacesAPI:
@@ -56,6 +56,18 @@ class TestWorkspacesAPI:
         assert isinstance(paginated_members.next_page_results, bool)
         for member in paginated_members.results:
             assert isinstance(member, WorkspaceMember)
+
+    def test_get_project_role_distribution(self, client: PlaneClient, workspace_slug: str) -> None:
+        """get_project_role_distribution returns aggregate role counts."""
+        distribution = client.workspaces.get_project_role_distribution(workspace_slug)
+        assert isinstance(distribution.total_memberships, int)
+        assert isinstance(distribution.total_distinct_members, int)
+        assert isinstance(distribution.roles, list)
+        for entry in distribution.roles:
+            assert isinstance(entry, ProjectRoleDistributionEntry)
+            assert hasattr(entry, "slug")
+            assert hasattr(entry, "membership_count")
+            assert hasattr(entry, "distinct_member_count")
 
     def test_get_features(self, client: PlaneClient, workspace_slug: str) -> None:
         """Test getting workspace features."""


### PR DESCRIPTION
### Description
Added support for new SDK APIs to improve project, cycle, module, and workspace querying.

### Changes

#### Lite List Endpoints
Added support for:
- `projects.list_lite()`
- `cycles.list_lite()`
- `modules.list_lite()`

These endpoints return lightweight, cursor-paginated responses for picker and lookup use cases.

#### Project Role Distribution
Added:
- `workspaces.get_project_role_distribution()`

This endpoint returns project member distribution across workspace roles.

#### Cycle Status Filtering
Added support for cycle status filtering using:
- `current`
- `upcoming`
- `completed`
- `draft`
- `incomplete`

Also added support for the deprecated `cycle_view` alias on the full cycle list endpoint.

#### SDK Updates
- Added new query parameter models.
- Added new response models for project role distribution.
- Updated enums and model exports.
- Updated README with new APIs and usage examples.

### Test Scenarios
- Verified lite project, cycle, and module endpoints.
- Tested workspace project role distribution endpoint.
- Verified cycle status filtering for all supported values.
- Tested pagination and query parameter serialization.
- Confirmed backward compatibility with existing SDK APIs.
- Verified documentation examples and unit tests.