### PR TITLE
feat: add Workload resource — estimates, matrix, parent rollups

### DIFF
--- a/plane/__init__.py
+++ b/plane/__init__.py
@@ -18,6 +18,7 @@ from .api.work_item_relation_definitions import WorkItemRelationDefinitions
 from .api.work_item_types import WorkItemTypes
 from .api.work_items import WorkItems
 from .api.workflows import Workflows, WorkflowStates, WorkflowTransitions
+from .api.workload import Workload
 from .api.workspace_project_labels import WorkspaceProjectLabels
 from .api.workspace_project_states import WorkspaceProjectStates
 from .api.workspace_templates import WorkspaceTemplates
@@ -34,7 +35,12 @@ from .client import (
     PlaneClient,
 )
 from .config import Configuration
-from .errors.errors import ConfigurationError, HttpError, PlaneError
+from .errors.errors import (
+    ConfigurationError,
+    HttpError,
+    PlaneError,
+    WorkloadParentHasChildrenError,
+)
 from .models.project_templates import (
     CreatePageTemplate,
     CreateWorkItemTemplate,
@@ -80,6 +86,7 @@ __all__ = [
     "Workflows",
     "WorkflowStates",
     "WorkflowTransitions",
+    "Workload",
     "ProjectTemplates",
     "ProjectWorkItemTemplates",
     "ProjectPageTemplates",
@@ -92,6 +99,7 @@ __all__ = [
     "PlaneError",
     "ConfigurationError",
     "HttpError",
+    "WorkloadParentHasChildrenError",
     "OAuthToken",
     "OAuthAuthorizationParams",
     "OAuthTokenExchangeParams",

--- a/plane/api/workload.py
+++ b/plane/api/workload.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..errors.errors import HttpError, WorkloadParentHasChildrenError
+from ..models.workload import (
+    UpdateWorkloadEstimate,
+    WorkloadEstimateDetail,
+    WorkloadMatrixResponse,
+    WorkloadQueryParams,
+    WorkloadRollup,
+)
+from .base_resource import BaseResource
+
+MAX_BULK_WORK_ITEM_IDS = 500
+
+
+def _prepare_matrix_params(params: WorkloadQueryParams) -> dict[str, Any]:
+    """Serialize :class:`WorkloadQueryParams` into HTTP query params.
+
+    CSV-joins the list fields (``project_ids``, ``assignee_ids``,
+    ``state_group``) — the API expects comma-separated strings, not
+    repeated query keys.
+    """
+    payload: dict[str, Any] = params.model_dump(exclude_none=True)
+    for key in ("project_ids", "assignee_ids", "state_group"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            payload[key] = ",".join(value)
+    return payload
+
+
+def _prepare_bulk_ids(work_item_ids: list[str]) -> str:
+    """Validate and CSV-join a bulk ``work_item_ids`` list.
+
+    Mirrors the server's cap/empty validation (shared by the bulk estimates
+    and bulk rollups endpoints) so callers fail fast without a round trip.
+    """
+    if not work_item_ids:
+        raise ValueError("work_item_ids must not be empty")
+    if len(work_item_ids) > MAX_BULK_WORK_ITEM_IDS:
+        raise ValueError(
+            f"Too many work_item_ids (max {MAX_BULK_WORK_ITEM_IDS}, " f"got {len(work_item_ids)})"
+        )
+    return ",".join(work_item_ids)
+
+
+class Workload(BaseResource):
+    """Resource for the workload feature: per-work-item time estimates, the
+    assignee x period workload matrix, and parent-rollup aggregation.
+    """
+
+    def __init__(self, config: Any) -> None:
+        super().__init__(config, "/workspaces/")
+
+    # ── Matrix ───────────────────────────────────────────────────
+
+    def get_matrix(
+        self, workspace_slug: str, params: WorkloadQueryParams
+    ) -> WorkloadMatrixResponse:
+        """Workspace-wide workload matrix (assignee x period hours).
+
+        Counts LEAF work items only — a work item with countable sub-items
+        never contributes its own estimate (its sub-items do; the parent's
+        aggregate is available via :meth:`list_rollups`). Defaults to
+        excluding ``completed``/``cancelled`` state groups unless
+        ``params.state_group`` is supplied.
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            params: Matrix query parameters (``granularity``, ``date_from``,
+                ``date_to`` are required; ``project_ids``, ``assignee_ids``,
+                ``state_group`` optionally narrow the result).
+        """
+        response = self._get(
+            f"{workspace_slug}/workload",
+            params=_prepare_matrix_params(params),
+        )
+        return WorkloadMatrixResponse.model_validate(response)
+
+    def get_project_matrix(
+        self, workspace_slug: str, project_id: str, params: WorkloadQueryParams
+    ) -> WorkloadMatrixResponse:
+        """Project-scoped workload matrix. Same shape/semantics as
+        :meth:`get_matrix`, narrowed to a single project.
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            project_id: UUID of the project.
+            params: Matrix query parameters.
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/workload",
+            params=_prepare_matrix_params(params),
+        )
+        return WorkloadMatrixResponse.model_validate(response)
+
+    # ── Single work-item estimate ───────────────────────────────
+
+    def get_estimate(
+        self, workspace_slug: str, project_id: str, work_item_id: str
+    ) -> WorkloadEstimateDetail:
+        """Retrieve the stored workload estimate for a work item.
+
+        For a PARENT work item (has one or more countable sub-items),
+        ``hours`` is always ``None`` and ``rollup`` carries the aggregated
+        total instead.
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            project_id: UUID of the project.
+            work_item_id: UUID of the work item.
+        """
+        response = self._get(
+            f"{workspace_slug}/projects/{project_id}/issues/{work_item_id}/workload-estimate",
+        )
+        return WorkloadEstimateDetail.model_validate(response)
+
+    def update_estimate(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        work_item_id: str,
+        data: UpdateWorkloadEstimate,
+    ) -> WorkloadEstimateDetail:
+        """Set the workload estimate (hours) for a work item.
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            project_id: UUID of the project.
+            work_item_id: UUID of the work item.
+            data: The new estimate (``hours``, 0..10000).
+
+        Raises:
+            WorkloadParentHasChildrenError: the work item has one or more
+                countable sub-items — set estimates on the sub-items
+                instead. ``error_code`` is always ``"PARENT_HAS_CHILDREN"``.
+        """
+        try:
+            response = self._put(
+                f"{workspace_slug}/projects/{project_id}/issues/{work_item_id}/workload-estimate",
+                data.model_dump(exclude_none=True),
+            )
+        except HttpError as exc:
+            if (
+                isinstance(exc.response, dict)
+                and exc.response.get("error_code") == "PARENT_HAS_CHILDREN"
+            ):
+                # exc.status_code is always set for a constructed HttpError; the
+                # attribute is typed as int | None only because the PlaneError
+                # base class allows None for ConfigurationError.
+                assert exc.status_code is not None
+                raise WorkloadParentHasChildrenError(
+                    str(exc), exc.status_code, exc.response
+                ) from exc
+            raise
+        return WorkloadEstimateDetail.model_validate(response)
+
+    def delete_estimate(self, workspace_slug: str, project_id: str, work_item_id: str) -> None:
+        """Delete the stored workload estimate for a work item.
+
+        Unlike :meth:`update_estimate`, this is allowed on parents (cleanup
+        of legacy/ignored rows).
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            project_id: UUID of the project.
+            work_item_id: UUID of the work item.
+        """
+        return self._delete(
+            f"{workspace_slug}/projects/{project_id}/issues/{work_item_id}/workload-estimate",
+        )
+
+    # ── Bulk ─────────────────────────────────────────────────────
+
+    def list_estimates(self, workspace_slug: str, work_item_ids: list[str]) -> dict[str, float]:
+        """Bulk-fetch stored estimates for up to 500 work items.
+
+        Returns ``{work_item_id: hours}``. Work items with no stored row
+        are omitted (treat as unset). Rows belonging to a PARENT work item
+        are also omitted — a parent's legacy hours never leak here; see
+        :meth:`list_rollups` for parent aggregates.
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            work_item_ids: Work item UUIDs to fetch (non-empty, max 500).
+
+        Raises:
+            ValueError: ``work_item_ids`` is empty or exceeds 500 entries.
+        """
+        response = self._get(
+            f"{workspace_slug}/workload-estimates",
+            params={"issue_ids": _prepare_bulk_ids(work_item_ids)},
+        )
+        return {str(k): float(v) for k, v in response.items()}
+
+    def list_rollups(
+        self, workspace_slug: str, work_item_ids: list[str]
+    ) -> dict[str, WorkloadRollup]:
+        """Bulk-fetch parent rollups for up to 500 work items.
+
+        Returns ``{work_item_id: WorkloadRollup}`` for ids that ARE parents
+        (one or more countable sub-items); non-parent ids — and ids outside
+        the caller's access — are both simply omitted (indistinguishable by
+        design; mirrors :meth:`list_estimates`).
+
+        Args:
+            workspace_slug: The workspace slug identifier.
+            work_item_ids: Work item UUIDs to fetch (non-empty, max 500).
+
+        Raises:
+            ValueError: ``work_item_ids`` is empty or exceeds 500 entries.
+        """
+        response = self._get(
+            f"{workspace_slug}/workload-rollups",
+            params={"issue_ids": _prepare_bulk_ids(work_item_ids)},
+        )
+        return {k: WorkloadRollup.model_validate(v) for k, v in response.items()}

--- a/plane/client/plane_client.py
+++ b/plane/client/plane_client.py
@@ -21,6 +21,7 @@ from ..api.work_item_relation_definitions import WorkItemRelationDefinitions
 from ..api.work_item_types import WorkItemTypes
 from ..api.work_items import WorkItems
 from ..api.workflows import Workflows
+from ..api.workload import Workload
 from ..api.workspace_project_labels import WorkspaceProjectLabels
 from ..api.workspace_project_states import WorkspaceProjectStates
 from ..api.workspace_templates import WorkspaceTemplates
@@ -75,6 +76,7 @@ class PlaneClient:
         self.initiatives = Initiatives(self.config)
         self.teamspaces = Teamspaces(self.config)
         self.workflows = Workflows(self.config)
+        self.workload = Workload(self.config)
         self.project_templates = ProjectTemplates(self.config)
         self.workspace_templates = WorkspaceTemplates(self.config)
         self.workspace_work_item_types = WorkspaceWorkItemTypes(self.config)

--- a/plane/errors/__init__.py
+++ b/plane/errors/__init__.py
@@ -1,3 +1,13 @@
-from .errors import ConfigurationError, HttpError, PlaneError
+from .errors import (
+    ConfigurationError,
+    HttpError,
+    PlaneError,
+    WorkloadParentHasChildrenError,
+)
 
-__all__ = ["PlaneError", "ConfigurationError", "HttpError"]
+__all__ = [
+    "PlaneError",
+    "ConfigurationError",
+    "HttpError",
+    "WorkloadParentHasChildrenError",
+]

--- a/plane/errors/errors.py
+++ b/plane/errors/errors.py
@@ -95,3 +95,18 @@ class HttpError(PlaneError):
             f"{type(self).__name__}(message={super().__str__()!r}, "
             f"status_code={self.status_code!r}, response={self.response!r})"
         )
+
+
+class WorkloadParentHasChildrenError(HttpError):
+    """Raised by ``Workload.update_estimate`` when the target work item has
+    one or more countable sub-items.
+
+    Workload estimates can only be set on leaf work items — a parent's
+    aggregate is surfaced via ``Workload.list_rollups`` /
+    ``WorkloadEstimateDetail.rollup`` instead. The underlying HTTP response
+    always carries ``{"error_code": "PARENT_HAS_CHILDREN"}``; this class
+    exposes that as :attr:`error_code` so callers can branch on it
+    programmatically instead of parsing the response body.
+    """
+
+    error_code: str = "PARENT_HAS_CHILDREN"

--- a/plane/models/workload.py
+++ b/plane/models/workload.py
@@ -1,0 +1,173 @@
+"""Models for the workload feature: per-work-item time estimates, the
+assignee x period workload matrix, and parent-rollup aggregation.
+
+Mirrors the server-side semantics implemented in ``apps/api/plane/workload/``
+of the plane fork (``aggregation.py`` / ``rollup.py`` / ``service.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+WorkloadGranularity = Literal["day", "week", "month"]
+
+
+class WorkloadRow(BaseModel):
+    """One assignee's scheduled hours, bucketed by period."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    assignee_id: str | None = None
+    assignee_name: str | None = None
+    buckets: dict[str, float] = Field(default_factory=dict)
+    total: float = 0.0
+
+
+class WorkloadUnscheduled(BaseModel):
+    """Hours with no ``target_date`` for one assignee — excluded from any
+    period bucket in the matrix."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    assignee_id: str | None = None
+    hours: float = 0.0
+
+
+class WorkloadMeta(BaseModel):
+    """Diagnostic counters accompanying a workload matrix response."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    issues_counted: int | None = None
+    issues_unscheduled: int | None = None
+    dirty_date_count: int | None = None
+    zero_estimate_count: int | None = None
+    truncated: bool | None = None
+    unscheduled_ratio: float | None = None
+
+
+class WorkloadMatrixResponse(BaseModel):
+    """Response for the workspace/project workload matrix endpoints.
+
+    Counts LEAF work items only — a work item with one or more countable
+    sub-items never contributes its own estimate to the matrix (its
+    sub-items do, individually; the parent's aggregate is available via
+    :meth:`~plane.api.workload.Workload.list_rollups`). Defaults to
+    excluding ``completed``/``cancelled`` state groups unless a
+    ``state_group`` filter was supplied on the request.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    granularity: WorkloadGranularity
+    date_from: str
+    date_to: str
+    periods: list[str] = Field(default_factory=list)
+    rows: list[WorkloadRow] = Field(default_factory=list)
+    unscheduled: list[WorkloadUnscheduled] = Field(default_factory=list)
+    meta: WorkloadMeta | None = None
+
+
+class WorkloadRollup(BaseModel):
+    """Aggregate rollup for a parent work item, computed over its full
+    descendant tree (max depth 10, capped at 10,000 traversed rows).
+
+    - ``hours``: sum of countable LEAF estimates (hours > 0) across the
+      entire descendant tree.
+    - ``done_hours``: subset of ``hours`` contributed by leaves whose state
+      group is ``completed``.
+    - ``percent``: ``round(done_hours / hours, 4)``; ``None`` when ``hours``
+      is 0 (no countable estimates yet — avoids a division by zero).
+    - ``due_date``: max ``target_date`` across ALL countable descendants
+      (leaves and intermediate nodes), as an ISO date string, or ``None``.
+    - ``leaf_count``: count of countable leaves with hours > 0.
+
+    A descendant is "countable" when it is not soft-deleted, not archived,
+    not a draft, and its state group is not ``cancelled``/``triage``.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    hours: float
+    done_hours: float
+    percent: float | None = None
+    due_date: str | None = None
+    leaf_count: int
+
+
+class WorkloadEstimateDetail(BaseModel):
+    """Response for the single work-item ``workload-estimate`` GET/PUT
+    endpoints.
+
+    ``hours`` is ``None`` when no estimate is stored, and is ALWAYS ``None``
+    for a parent work item (``is_parent=True``) — a legacy stored value
+    never leaks once a work item has countable sub-items; set estimates on
+    the sub-items instead. ``is_parent`` / ``rollup`` are populated on GET
+    only; the PUT response never carries them (a PUT can only succeed
+    against a leaf work item — see
+    :class:`~plane.errors.errors.WorkloadParentHasChildrenError`).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    work_item_id: str | None = Field(default=None, alias="issue")
+    hours: float | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    is_parent: bool | None = None
+    rollup: WorkloadRollup | None = None
+
+
+class UpdateWorkloadEstimate(BaseModel):
+    """Request body for ``PUT .../workload-estimate/``."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    hours: float = Field(..., ge=0, le=10000)
+
+
+class WorkloadQueryParams(BaseModel):
+    """Query parameters for the workspace/project workload matrix
+    endpoints.
+
+    ``granularity``, ``date_from``, and ``date_to`` are required. Date span
+    is capped server-side depending on granularity (92 days for ``day``,
+    366 for ``week``, 730 for ``month``).
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    granularity: WorkloadGranularity
+    date_from: str
+    date_to: str
+    project_ids: list[str] | None = Field(
+        default=None,
+        description="Work item project UUIDs to narrow the matrix to. CSV-joined on the wire.",
+    )
+    assignee_ids: list[str] | None = Field(
+        default=None,
+        description="Assignee UUIDs to narrow the matrix to. CSV-joined on the wire.",
+    )
+    state_group: list[str] | None = Field(
+        default=None,
+        description=(
+            "State groups to include (overrides the completed/cancelled "
+            "default exclusion). CSV-joined on the wire."
+        ),
+    )
+
+
+__all__ = [
+    "WorkloadGranularity",
+    "WorkloadRow",
+    "WorkloadUnscheduled",
+    "WorkloadMeta",
+    "WorkloadMatrixResponse",
+    "WorkloadRollup",
+    "WorkloadEstimateDetail",
+    "UpdateWorkloadEstimate",
+    "WorkloadQueryParams",
+]

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -1,0 +1,271 @@
+"""Unit tests for the Workload API resource (smoke tests with real HTTP
+requests, plus offline model-validation tests)."""
+
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from plane.client import PlaneClient
+from plane.errors.errors import WorkloadParentHasChildrenError
+from plane.models.projects import Project
+from plane.models.work_items import CreateWorkItem
+from plane.models.workload import (
+    UpdateWorkloadEstimate,
+    WorkloadEstimateDetail,
+    WorkloadMatrixResponse,
+    WorkloadQueryParams,
+    WorkloadRollup,
+)
+
+
+class TestWorkloadEstimateAPI:
+    """Test the single work-item estimate GET/PUT/DELETE endpoints."""
+
+    @pytest.fixture
+    def work_item(self, client: PlaneClient, workspace_slug: str, project: Project):
+        """Create a leaf work item and yield it, then delete it."""
+        work_item = client.work_items.create(
+            workspace_slug,
+            project.id,
+            CreateWorkItem(name=f"Workload Test Leaf {int(time.time() * 1000)}"),
+        )
+        yield work_item
+        try:
+            client.work_items.delete(workspace_slug, project.id, work_item.id)
+        except Exception:
+            pass
+
+    def test_get_estimate_unset_returns_none_hours(
+        self, client: PlaneClient, workspace_slug: str, project: Project, work_item
+    ) -> None:
+        """A leaf work item with no stored estimate returns hours=None."""
+        estimate = client.workload.get_estimate(workspace_slug, project.id, work_item.id)
+        assert isinstance(estimate, WorkloadEstimateDetail)
+        assert estimate.hours is None
+        assert estimate.is_parent is False
+
+    def test_update_and_get_estimate(
+        self, client: PlaneClient, workspace_slug: str, project: Project, work_item
+    ) -> None:
+        """Setting an estimate on a leaf work item persists and round-trips."""
+        updated = client.workload.update_estimate(
+            workspace_slug,
+            project.id,
+            work_item.id,
+            UpdateWorkloadEstimate(hours=4.5),
+        )
+        assert isinstance(updated, WorkloadEstimateDetail)
+        assert updated.hours == 4.5
+        assert updated.work_item_id == work_item.id
+
+        fetched = client.workload.get_estimate(workspace_slug, project.id, work_item.id)
+        assert fetched.hours == 4.5
+        assert fetched.is_parent is False
+        assert fetched.rollup is None
+
+    def test_delete_estimate(
+        self, client: PlaneClient, workspace_slug: str, project: Project, work_item
+    ) -> None:
+        """Deleting a stored estimate clears it back to unset."""
+        client.workload.update_estimate(
+            workspace_slug, project.id, work_item.id, UpdateWorkloadEstimate(hours=2)
+        )
+        result = client.workload.delete_estimate(workspace_slug, project.id, work_item.id)
+        assert result is None
+
+        fetched = client.workload.get_estimate(workspace_slug, project.id, work_item.id)
+        assert fetched.hours is None
+
+
+class TestWorkloadParentRollup:
+    """Test parent-rollup behavior: single-GET, PUT-block, bulk endpoints."""
+
+    @pytest.fixture
+    def parent_with_child(self, client: PlaneClient, workspace_slug: str, project: Project):
+        """Create a parent work item with one countable child estimate, yield
+        (parent, child), then delete both."""
+        timestamp = int(time.time() * 1000)
+        parent = client.work_items.create(
+            workspace_slug,
+            project.id,
+            CreateWorkItem(name=f"Workload Test Parent {timestamp}"),
+        )
+        child = client.work_items.create(
+            workspace_slug,
+            project.id,
+            CreateWorkItem(
+                name=f"Workload Test Child {timestamp}",
+                parent=parent.id,
+            ),
+        )
+        client.workload.update_estimate(
+            workspace_slug, project.id, child.id, UpdateWorkloadEstimate(hours=3)
+        )
+        yield parent, child
+        for item_id in (child.id, parent.id):
+            try:
+                client.work_items.delete(workspace_slug, project.id, item_id)
+            except Exception:
+                pass
+
+    def test_parent_single_get_has_rollup_and_null_hours(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+        parent_with_child,
+    ) -> None:
+        parent, _child = parent_with_child
+        estimate = client.workload.get_estimate(workspace_slug, project.id, parent.id)
+        assert estimate.hours is None
+        assert estimate.is_parent is True
+        assert estimate.rollup is not None
+        assert isinstance(estimate.rollup, WorkloadRollup)
+        assert estimate.rollup.leaf_count >= 1
+        assert estimate.rollup.hours >= 3
+
+    def test_put_on_parent_raises_typed_error(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+        parent_with_child,
+    ) -> None:
+        parent, _child = parent_with_child
+        with pytest.raises(WorkloadParentHasChildrenError) as exc_info:
+            client.workload.update_estimate(
+                workspace_slug, project.id, parent.id, UpdateWorkloadEstimate(hours=1)
+            )
+        assert exc_info.value.error_code == "PARENT_HAS_CHILDREN"
+        assert exc_info.value.status_code == 400
+
+    def test_bulk_estimates_omits_parent(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+        parent_with_child,
+    ) -> None:
+        parent, child = parent_with_child
+        result = client.workload.list_estimates(workspace_slug, [parent.id, child.id])
+        assert child.id in result
+        assert result[child.id] == 3.0
+        assert parent.id not in result
+
+    def test_bulk_rollups_returns_parent_only(
+        self,
+        client: PlaneClient,
+        workspace_slug: str,
+        project: Project,
+        parent_with_child,
+    ) -> None:
+        parent, child = parent_with_child
+        result = client.workload.list_rollups(workspace_slug, [parent.id, child.id])
+        assert parent.id in result
+        assert child.id not in result
+        assert isinstance(result[parent.id], WorkloadRollup)
+
+
+class TestWorkloadMatrix:
+    """Test the workspace/project workload matrix endpoints."""
+
+    def test_get_matrix_well_formed(self, client: PlaneClient, workspace_slug: str) -> None:
+        """Only asserts response shape — parallel test data may pollute
+        exact totals, so this does not assert on row/period values."""
+        result = client.workload.get_matrix(
+            workspace_slug,
+            WorkloadQueryParams(
+                granularity="day",
+                date_from="2026-08-01",
+                date_to="2026-08-31",
+            ),
+        )
+        assert isinstance(result, WorkloadMatrixResponse)
+        assert result.granularity == "day"
+        assert result.date_from == "2026-08-01"
+        assert result.date_to == "2026-08-31"
+        assert isinstance(result.rows, list)
+        assert isinstance(result.periods, list)
+        assert isinstance(result.unscheduled, list)
+
+    def test_get_project_matrix_well_formed(
+        self, client: PlaneClient, workspace_slug: str, project: Project
+    ) -> None:
+        result = client.workload.get_project_matrix(
+            workspace_slug,
+            project.id,
+            WorkloadQueryParams(
+                granularity="week",
+                date_from="2026-08-01",
+                date_to="2026-08-31",
+            ),
+        )
+        assert isinstance(result, WorkloadMatrixResponse)
+        assert result.granularity == "week"
+
+
+class TestWorkloadModels:
+    """Offline Pydantic model-validation tests (no network)."""
+
+    def test_update_workload_estimate_rejects_negative_hours(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateWorkloadEstimate(hours=-1)
+
+    def test_update_workload_estimate_rejects_over_max(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateWorkloadEstimate(hours=10001)
+
+    def test_update_workload_estimate_valid(self) -> None:
+        data = UpdateWorkloadEstimate(hours=7.5)
+        assert data.hours == 7.5
+
+    def test_query_params_requires_granularity_and_dates(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkloadQueryParams()
+
+    def test_query_params_accepts_optional_filters(self) -> None:
+        params = WorkloadQueryParams(
+            granularity="month",
+            date_from="2026-01-01",
+            date_to="2026-12-31",
+            project_ids=["p1", "p2"],
+            assignee_ids=["a1"],
+            state_group=["started", "backlog"],
+        )
+        assert params.project_ids == ["p1", "p2"]
+
+    def test_estimate_detail_allows_extra_fields(self) -> None:
+        detail = WorkloadEstimateDetail.model_validate(
+            {"hours": None, "is_parent": True, "some_future_field": "x"}
+        )
+        assert detail.hours is None
+        assert detail.is_parent is True
+        assert detail.some_future_field == "x"
+
+    def test_estimate_detail_maps_issue_alias_to_work_item_id(self) -> None:
+        detail = WorkloadEstimateDetail.model_validate(
+            {"id": "est-1", "issue": "work-item-1", "hours": 2.0}
+        )
+        assert detail.work_item_id == "work-item-1"
+
+    def test_rollup_percent_none_when_hours_zero(self) -> None:
+        rollup = WorkloadRollup.model_validate(
+            {"hours": 0, "done_hours": 0, "percent": None, "due_date": None, "leaf_count": 0}
+        )
+        assert rollup.percent is None
+
+    def test_matrix_response_defaults(self) -> None:
+        matrix = WorkloadMatrixResponse.model_validate(
+            {
+                "granularity": "day",
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-31",
+                "periods": [],
+                "rows": [],
+                "unscheduled": [],
+                "meta": {"issues_counted": 0},
+            }
+        )
+        assert matrix.rows == []
+        assert matrix.meta.issues_counted == 0


### PR DESCRIPTION
## Summary

The SDK had **no workload bindings at all**. This adds the complete surface for the plane fork's `workload` app (estimates, matrix, parent rollups), not just the rollup-only addition the issue titled — the SDK had nothing to extend.

- `client.workload.get_matrix(workspace_slug, params)` — `GET /workspaces/{slug}/workload/`
- `client.workload.get_project_matrix(workspace_slug, project_id, params)` — `GET /workspaces/{slug}/projects/{project_id}/workload/`
- `client.workload.get_estimate(workspace_slug, project_id, work_item_id)` — `GET .../issues/{id}/workload-estimate/`
- `client.workload.update_estimate(workspace_slug, project_id, work_item_id, data)` — `PUT` same path; raises a **typed** `WorkloadParentHasChildrenError(HttpError)` (with `.error_code == "PARENT_HAS_CHILDREN"`) instead of a bare `HttpError` when the target has countable sub-items
- `client.workload.delete_estimate(workspace_slug, project_id, work_item_id)` — `DELETE` same path (allowed on parents, unlike PUT)
- `client.workload.list_estimates(workspace_slug, work_item_ids)` — `GET /workspaces/{slug}/workload-estimates/?issue_ids=...` → `{work_item_id: hours}`, parent rows omitted, cap 500
- `client.workload.list_rollups(workspace_slug, work_item_ids)` — `GET /workspaces/{slug}/workload-rollups/?issue_ids=...` → `{work_item_id: WorkloadRollup}`, parents-only, cap 500

New models in `plane/models/workload.py`: `WorkloadMatrixResponse`, `WorkloadRow`, `WorkloadUnscheduled`, `WorkloadMeta`, `WorkloadRollup`, `WorkloadEstimateDetail`, `UpdateWorkloadEstimate`, `WorkloadQueryParams`. Rollup semantics (full-tree depth 10, "countable" predicate, `percent=None` when `hours=0`) are documented in the model docstrings, mirroring `apps/api/plane/workload/rollup.py` in the fork.

Endpoint/parameter naming follows repo convention: the server's literal `.../issues/<id>/...` path segment is unavoidable (fixed URL), but all SDK-facing parameter and method names use `work_item_id` / `work_item_ids`, never "issue".

## Test plan

**Repo gates** (`black`, `ruff`, `mypy`, `pytest`) run in a fresh venv against a clean install of this branch:
- `black --check` — clean on all touched/new files (one pre-existing unrelated formatting drift in `errors.py`'s `HttpError.__init__` predates this branch — confirmed via `git stash` against `main`, left untouched per surgical-change discipline)
- `ruff check` — `All checks passed!` on all touched/new files
- `mypy plane` — **46 errors before and after this change** (verified via `git stash` diff against `main`) — zero new errors introduced by this PR
- `pytest tests/unit/` — `85 passed, 221 skipped` (network tests skip without `PLANE_BASE_URL`/`PLANE_API_KEY` env vars, matching existing repo convention); `tests/unit/test_workload.py` alone: `9 passed, 9 skipped`

**Live E2E** against the deployed fork stack (`http://localhost:20080`, workspace `the-one-game-studio`, project `Voodoo`), using **only the new SDK code** (no raw HTTP):
- Seeded an isolated test tree (marker `E2E-SDK-PY`, parallel-safe): Parent → {C1 done 6h, C2 started 4h, C3 cancelled 50h, C4 (unstarted, no own estimate) → G1 unstarted 2h}
- `list_rollups([Parent, C1, C2, C3, C4, G1])` → Parent present with `hours=12.0, done_hours=6.0, percent=0.5, due_date="2026-08-20", leaf_count=3`; true leaves (C1/C2/C3/G1) absent; C4 correctly present too (it's *also* a parent, of G1)
- `get_estimate(Parent)` → `hours=None, is_parent=True, rollup` matches the bulk rollup exactly
- `get_estimate(C1)` → `hours=6.0, is_parent=False, rollup=None`
- `update_estimate(Parent, hours=5)` → raises `WorkloadParentHasChildrenError` with `error_code=="PARENT_HAS_CHILDREN"`, `status_code==400`
- `list_estimates([Parent, C1, C2, C3, C4, G1])` → Parent and C4 (both parents) omitted; C1/C2/G1 exact hours; **C3's 50h correctly present** (confirmed against `apps/api/plane/workload/service.py::bulk_estimates` — it has no state-group filter, only the matrix endpoint excludes cancelled/completed)
- `get_matrix(...)` / `get_project_matrix(...)` → well-formed response shape (granularity/date echo, all list fields present); no exact-total assertions since parallel test runs share the workspace
- **All 30 assertions passed** on the second run (two assertions failed on the first pass due to wrong test expectations on my part, not SDK bugs — fixed by reading the server source, see commit history of the scratch script)
- **Cleanup verified**: all 6 seeded issues hard-deleted (`Issue.all_objects.filter(name__startswith="E2E-SDK-PY").count() == 0`) and the `sdk-e2e-py` API token hard-deleted (`APIToken.all_objects.filter(label="sdk-e2e-py").count() == 0`)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDA1JjtePo7qPyE3CiQcVv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workload support to the client, including matrix views, estimate details, bulk estimate lookups, and rollup data.
  * Exposed workload-related types and errors for easier handling in integrations.
  * Added validation for workload inputs, including limits on bulk item requests and estimate ranges.

* **Bug Fixes**
  * Improved error handling when updating estimates for parent items with child work items, returning a clearer error condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->