### PR TITLE
fix: accept UUID-string assignees/labels in WorkItemDetail

### DIFF
--- a/plane/models/work_items.py
+++ b/plane/models/work_items.py
@@ -53,8 +53,12 @@ class WorkItemDetail(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     id: str | None = None
-    assignees: list[UserLite] = Field(default_factory=list)
-    labels: list[Label] = Field(default_factory=list)
+    # The API returns these as either a list of UUID strings or a list of
+    # expanded objects (depending on ?expand=), so accept both — mirroring
+    # WorkItemExpand. A bare list[UserLite]/list[Label] rejected the string
+    # form and raised a ValidationError on retrieve().
+    assignees: list[str] | list[UserLite] = Field(default_factory=list)
+    labels: list[str] | list[Label] = Field(default_factory=list)
     type_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None


### PR DESCRIPTION
### Description
The work item retrieve endpoints return `assignees` and `labels` as either a list of UUID strings or a list of expanded objects, depending on `?expand=`. WorkItemDetail typed them as bare `list[UserLite]` / `list[Label]`, so the string form raised a pydantic ValidationError — breaking retrieve_work_item, retrieve_work_item_by_identifier and the assignee/label management tools that call retrieve() first.

Widen to `list[str] | list[UserLite]` / `list[str] | list[Label]`, mirroring WorkItemExpand which already handled both shapes. Default stays an empty list.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed work item details failing validation when assignees or labels are returned as UUIDs instead of expanded objects.
  * Work item details now consistently support both compact ID lists and expanded assignee or label data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->