### PR TITLE
fix: make WorkspaceFeature fields optional for partial updates

### DIFF
--- a/plane/models/workspaces.py
+++ b/plane/models/workspaces.py
@@ -27,16 +27,20 @@ class PaginatedWorkspaceMemberResponse(PaginatedResponse):
 
 
 class WorkspaceFeature(BaseModel):
-    """Workspace feature model."""
+    """Workspace feature model.
+
+    All fields are optional so a caller can toggle a single feature; the update
+    endpoint is a partial (PATCH) that only applies the fields that are sent.
+    """
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    project_grouping: bool
-    initiatives: bool
-    teams: bool
-    customers: bool
-    wiki: bool
-    pi: bool
+    project_grouping: bool | None = None
+    initiatives: bool | None = None
+    teams: bool | None = None
+    customers: bool | None = None
+    wiki: bool | None = None
+    pi: bool | None = None
 
 
 class ProjectRoleDistributionEntry(BaseModel):


### PR DESCRIPTION
### Description
Updates the `WorkspaceFeature` model to make all feature fields optional, aligning it with the workspace feature update (PATCH) API. This allows callers to update only the features they want without providing the entire payload.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios
- Verified partial workspace feature updates serialize correctly.
- Confirmed omitted fields are not included in the request payload.

### References
N/A